### PR TITLE
feat(pyodide): Phase 1 manifest, skill, and preflight corpus

### DIFF
--- a/src/agent/runtime/capability-router.ts
+++ b/src/agent/runtime/capability-router.ts
@@ -41,9 +41,9 @@ export const CAPABILITY_ROUTES: CapabilityRoute[] = [
   },
   {
     need: "Python scripts",
-    skill: "browser-runtime-map",
+    skill: "pyodide-runtime",
     tools: ["run_python"],
-    avoid: "run_shell python3 except alias",
+    avoid: "run_shell python3 except alias; host subprocess/pip/TCP",
   },
   {
     need: "Shell (last resort)",
@@ -137,7 +137,7 @@ export const CAPABILITY_ENV_FOOTER =
   "Environment: Nodebox browser — no POSIX shell, Pyodide Python, proxy-backed HTTP. " +
   "Bytes move runtime→proxy→upstream; model sees metadata only (never base64 in tool args). " +
   "CMS /files → web_upload; JSON/GraphQL → web_post; binary download → web_fetch save_to. " +
-  "Full matrix: skill_view **`browser-runtime-map`**. " +
+  "Python codegen: skill_view **`pyodide-runtime`**; tool picker: **`browser-runtime-map`**. " +
   "Installed capability folders: `capability_list` (extensions only, not built-in routing).";
 
 const ROUTER_CHAR_BUDGET = 1800;

--- a/src/agent/runtime/tools/builtins/run_python.ts
+++ b/src/agent/runtime/tools/builtins/run_python.ts
@@ -15,7 +15,7 @@ export default defineTool({
   run: runPythonTool,
   emoji: "🐍",
   description:
-    "Run Python in browser-only Nodebox via lazy Pyodide (v0.29.4). **Prefer over `run_shell python3`.** Agent one-off REST → `web_fetch`/`web_post`; file uploads → `web_upload`; HTTP inside scripts → `import webagent.http as http` (`upload_file` for files). Supports `code` or workspace `path`, optional `args`, `cwd`, `env`, `packages`, `timeout_ms`. **Create ZIP:** stdlib `zipfile` (no `create_archive` tool). Auto-loads common Pyodide wheels. Hard-blocked: host binaries/subprocess, Playwright, raw DB sockets. Examples: " +
+    "Run Python in browser-only Nodebox via lazy Pyodide (v0.29.4). **Before codegen:** `skill_view` **`pyodide-runtime`** (WASM contract). **Prefer over `run_shell python3`.** Agent one-off REST → `web_fetch`/`web_post`; file uploads → `web_upload`; HTTP inside scripts → `import webagent.http as http` (`upload_file` for files). Supports `code` or workspace `path`, optional `args`, `cwd`, `env`, `packages`, `timeout_ms`. **Create ZIP:** stdlib `zipfile` (no `create_archive` tool). Auto-loads common Pyodide wheels. Hard-blocked: host binaries/subprocess, Playwright, raw DB sockets. Examples: " +
     JSON.stringify(RUN_PYTHON_EXAMPLES[0]) +
     " | " +
     JSON.stringify(RUN_PYTHON_EXAMPLES[1]),

--- a/src/agent/runtime/tools/builtins/skill_view.ts
+++ b/src/agent/runtime/tools/builtins/skill_view.ts
@@ -5,6 +5,7 @@ const SKILL_VIEW_EXAMPLES = [
   { name: "http-api" },
   { name: "memory-layers" },
   { name: "browser-runtime-map" },
+  { name: "pyodide-runtime" },
 ];
 
 export default defineTool({

--- a/src/capabilities/skills/browser-runtime-map/SKILL.md
+++ b/src/capabilities/skills/browser-runtime-map/SKILL.md
@@ -80,6 +80,8 @@ Three layers:
 
 ## Python in Pyodide — what works vs. what doesn't
 
+Full agent contract and checklist: **`skill_view` `pyodide-runtime`**. Capability manifest: `src/runtimes/webcontainer/pyodide-capabilities.json`.
+
 | Python pattern | Status | Alternative |
 |---|---|---|
 | stdlib (`json`, `re`, `pathlib`, `csv`, …) | **Works** | — |

--- a/src/capabilities/skills/imported-skill-compat/SKILL.md
+++ b/src/capabilities/skills/imported-skill-compat/SKILL.md
@@ -55,7 +55,7 @@ Remote imports auto-append a **Web Agent execution (auto-appended)** section to 
 
 ## Relation to other skills
 
-- Install discovery: **`find-skills`**. Remote install rules: **`web-agent-skill`**. Runtime picker: **`browser-runtime-map`**. HTTP: **`http-api`**. Python: **`run_python`**.
+- Install discovery: **`find-skills`**. Remote install rules: **`web-agent-skill`**. Runtime picker: **`browser-runtime-map`**. HTTP: **`http-api`**. Python: **`run_python`** + **`pyodide-runtime`** for WASM-safe codegen.
 
 ## Pitfalls
 

--- a/src/capabilities/skills/pyodide-runtime/SKILL.md
+++ b/src/capabilities/skills/pyodide-runtime/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: Pyodide Runtime
+description: Use when writing or fixing Python for run_python — browser WASM Pyodide contract, forbidden APIs, package substitutes, and webagent.http.
+version: 1.0.0
+category: bundled
+primary-tools: [run_python, web_fetch, web_post, web_upload, skill_view]
+tags: [pyodide, python, wasm, browser, run_python, micropip, webagent.http]
+triggers: [run_python, pyodide, python script, micropip, browser python, wasm python, python in browser, incompatible python]
+---
+
+## Tool contract (read first)
+
+| Need | Use |
+|------|-----|
+| Run Python in workspace | `run_python` (`code` or `path`, optional `cwd`, `env`, `packages`, `timeout_ms`) |
+| One-off REST from agent | `web_fetch` / `web_post` / `web_upload` — not `requests` in chat args |
+| HTTP inside a reusable `.py` | `import webagent.http as http` (proxy-backed) |
+| File bytes to API | `http.upload_file` in script, or agent `web_upload` |
+| Shell / git / curl / npx | **`browser-runtime-map`** — not available in Nodebox |
+| Import map & blocks | Static preflight before worker; see **`browser-runtime-map`** Pyodide table |
+
+**Non-negotiable:** Read this skill (or `skill_view` **`browser-runtime-map`**) before generating Python. Capability manifest: `src/runtimes/webcontainer/pyodide-capabilities.json`. Substitution patterns: `src/runtimes/webcontainer/pyodide-substitution-matrix.json`.
+
+## When to Use
+
+- Any `run_python` call or skill script that will execute in the browser.
+- User asks for Python that assumes Linux, pip, subprocess, localhost, or native wheels.
+- Preflight blocked the script or returned `pyodide_*` errors.
+
+**Not for:** simple PDF/DOCX text extraction — try `pdf_extract` / `docx_extract` first.
+
+## Runtime contract (Pyodide)
+
+Your execution environment is **not** native Python.
+
+| Fact | Implication |
+|------|-------------|
+| Pyodide + WASM in a browser tab | No OS, no Docker, no real `/home/user` |
+| Virtual Emscripten FS | Write under `run_python` `cwd`; host mirrors workspace |
+| No subprocess / native binaries | No `soffice`, `git`, `ffmpeg`, `pdftoppm`, `tesseract`, … |
+| No raw TCP | No `psycopg2`, `pymongo`, `redis`, `socket.create_connection` |
+| Networking = browser fetch | CORS + `/api/proxy`; use `webagent.http` or agent HTTP tools |
+| Threads limited | Prefer async + `await asyncio.sleep(0)` for long work |
+| Packages | Stdlib, Pyodide wheels (auto-loaded), micropip allowlist only |
+
+### Forbidden (never generate)
+
+`subprocess`, `multiprocessing`, `os.system`, `pty`, `pexpect`, `signal`, `resource`, `pwd`, `grp`, `fcntl`, `asyncio.create_subprocess_exec`, `playwright`, `selenium`, `torch`, `tensorflow`, `cv2`, `pdf2image`, host DB drivers opening TCP.
+
+### Avoid (prefer alternatives)
+
+`threading` for parallelism, raw `socket` clients, `requests`/`httpx` for new code (use `webagent.http`), `sys.stdout.reconfigure`, `LD_PRELOAD` / `ctypes.CDLL("*.so")`, unbounded sync loops.
+
+### Preferred stack (priority order)
+
+1. Browser-native: agent `web_fetch` / `web_post` / `web_upload`
+2. In-script: `import webagent.http as http`
+3. Stdlib: `json`, `csv`, `pathlib`, `zipfile`, `re`, `hashlib`, …
+4. Pyodide wheels: `pypdf`, `python-docx`, `openpyxl`, `Pillow`, `numpy`, … (often auto-loaded)
+5. `pyodide.http.pyfetch` only when same-origin/CORS allows direct fetch
+
+### Decision checklist (before codegen)
+
+1. Will this run in browser WASM?  
+2. Does it need OS access, binaries, or real TCP?  
+3. Does it block the UI thread?  
+4. Is every import stdlib, Pyodide-bundled, or micropip-allowlisted?
+
+If any answer is wrong → redesign (see substitution matrix).
+
+### Good vs bad HTTP
+
+```python
+# Good — inside run_python
+import webagent.http as http
+resp = http.get("https://api.example.com/data")
+data = resp.json()
+
+# Bad — host assumptions
+import requests
+requests.get("http://localhost:3000")
+```
+
+## Relation to other skills
+
+- Tool picker & CLI redirects: **`browser-runtime-map`**
+- HTTP field shapes: **`http-api`**
+- Imported skills.sh scripts: **`imported-skill-compat`** (`script_warnings` from preflight)
+- ZIP create: stdlib `zipfile` here; extract: `extract_archive`
+
+## Pitfalls
+
+- Treating `run_shell python3` as full CPython — use `run_python` with Pyodide rules.
+- `pip install` in script — use `packages` arg or preflight auto-load / micropip allowlist.
+- Assuming `~/.config`, `/var/tmp`, or persistent paths outside workspace cwd.
+- Large base64 bodies in HTTP tool args — use `web_upload` / `http.upload_file`.
+
+## Anti-patterns
+
+- `subprocess.run(["git", …])` or `os.system("curl …")` in browser Python.
+- `import playwright` / `from pdf2image import convert_from_path` after preflight already warned.
+- `while True: pass` without `timeout_ms` on the tool call.

--- a/src/runtimes/webcontainer/pyodide-capabilities.json
+++ b/src/runtimes/webcontainer/pyodide-capabilities.json
@@ -1,0 +1,18 @@
+{
+  "runtime": "pyodide",
+  "version": "0.29.4",
+  "environment": "browser-wasm",
+  "supports_subprocess": false,
+  "supports_native_modules": false,
+  "supports_tcp": false,
+  "supports_threads": "limited",
+  "persistent_storage": "workspace-opfs-via-host",
+  "networking": "fetch-via-webagent-http-bridge",
+  "filesystem": "virtual-emscripten-fs",
+  "js_interop": true,
+  "preferred_http": "webagent.http",
+  "agent_http_tools": ["web_fetch", "web_post", "web_upload"],
+  "micropip_allowlist": ["feedparser"],
+  "substitution_matrix": "pyodide-substitution-matrix.json",
+  "preflight": "python-preflight.ts"
+}

--- a/src/runtimes/webcontainer/pyodide-substitution-matrix.json
+++ b/src/runtimes/webcontainer/pyodide-substitution-matrix.json
@@ -1,0 +1,103 @@
+{
+  "forbidden_imports": {
+    "requests": {
+      "prefer": ["webagent.http", "web_fetch", "web_post"],
+      "note": "May hit JsProxy in Pyodide; prefer webagent.http inside run_python"
+    },
+    "httpx": {
+      "prefer": ["webagent.http", "web_fetch", "web_post"],
+      "note": "Async HTTP fragile in Pyodide"
+    },
+    "aiohttp": {
+      "prefer": ["webagent.http", "web_fetch", "web_post"],
+      "note": "Async HTTP fragile in Pyodide"
+    },
+    "urllib3": {
+      "prefer": ["webagent.http", "urllib.request"],
+      "note": "Use proxy-backed urllib or webagent.http"
+    },
+    "pdf2image": {
+      "prefer": ["pypdf"],
+      "note": "Requires poppler pdftoppm at runtime"
+    },
+    "playwright": {
+      "prefer": ["web_fetch"],
+      "note": "No browser process in WASM"
+    },
+    "selenium": {
+      "prefer": ["web_fetch"],
+      "note": "No browser driver in WASM"
+    },
+    "torch": {
+      "prefer": ["web_post"],
+      "note": "Use hosted inference API"
+    },
+    "tensorflow": {
+      "prefer": ["web_post"],
+      "note": "Use hosted inference API"
+    },
+    "cv2": {
+      "prefer": ["PIL"],
+      "note": "OpenCV not in Pyodide; use Pillow for basic ops"
+    },
+    "psycopg2": {
+      "prefer": ["web_fetch", "web_post"],
+      "note": "No raw TCP; use database HTTP API"
+    },
+    "wikipedia": {
+      "prefer": ["web_fetch"],
+      "note": "Use Wikipedia REST API, not micropip package"
+    }
+  },
+  "forbidden_binaries": {
+    "soffice": "python-docx, python-pptx, openpyxl",
+    "git": "web_fetch + GitHub REST API",
+    "ffmpeg": "hosted transcoding API or imageio without ffmpeg backend",
+    "pdftoppm": "pypdf extract_text; server-side rasterize",
+    "tesseract": "hosted OCR via web_post",
+    "curl": "web_fetch",
+    "pandoc": "markitdown, python-docx, reportlab"
+  },
+  "patterns": [
+    {
+      "task": "HTTP GET JSON API",
+      "bad": "requests.get(url).json()",
+      "good": "import webagent.http as http\nhttp.get(url).json()"
+    },
+    {
+      "task": "HTTP POST JSON",
+      "bad": "requests.post(url, json=payload)",
+      "good": "web_post at agent level, or webagent.http.post inside run_python"
+    },
+    {
+      "task": "Create ZIP bundle",
+      "bad": "subprocess.run(['zip', ...])",
+      "good": "zipfile.ZipFile under work/<slug>/bundle.zip"
+    },
+    {
+      "task": "PDF text extract",
+      "bad": "subprocess.run(['pdftotext', ...])",
+      "good": "from pypdf import PdfReader"
+    },
+    {
+      "task": "Word doc edit",
+      "bad": "subprocess.run(['soffice', '--convert-to', ...])",
+      "good": "import docx"
+    },
+    {
+      "task": "Clone git repo",
+      "bad": "subprocess.run(['git', 'clone', ...])",
+      "good": "web_fetch GitHub API or upload zip + extract_archive"
+    },
+    {
+      "task": "Long CPU loop",
+      "bad": "while True: pass",
+      "good": "await asyncio.sleep(0) in async chunks; set timeout_ms"
+    },
+    {
+      "task": "Persist config",
+      "bad": "open('/home/user/.config/app.json')",
+      "good": "write under run_python cwd; host persists workspace via OPFS"
+    }
+  ]
+}

--- a/tests/pyodide-manifest.test.ts
+++ b/tests/pyodide-manifest.test.ts
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import nodePath from "node:path";
+
+import { PYODIDE_VERSION } from "../src/runtimes/webcontainer/pyodide-config.js";
+
+const RUNTIME_DIR = nodePath.join(process.cwd(), "src/runtimes/webcontainer");
+
+test("pyodide-capabilities.json matches pinned Pyodide version", async () => {
+  const raw = await fs.readFile(nodePath.join(RUNTIME_DIR, "pyodide-capabilities.json"), "utf8");
+  const manifest = JSON.parse(raw) as Record<string, unknown>;
+  assert.equal(manifest.runtime, "pyodide");
+  assert.equal(manifest.version, PYODIDE_VERSION);
+  assert.equal(manifest.environment, "browser-wasm");
+  assert.equal(manifest.supports_subprocess, false);
+  assert.equal(manifest.supports_native_modules, false);
+  assert.equal(manifest.supports_tcp, false);
+  assert.equal(manifest.networking, "fetch-via-webagent-http-bridge");
+  assert.equal(manifest.filesystem, "virtual-emscripten-fs");
+  assert.equal(manifest.js_interop, true);
+  assert.equal(manifest.preferred_http, "webagent.http");
+});
+
+test("pyodide-substitution-matrix.json has forbidden imports and patterns", async () => {
+  const raw = await fs.readFile(nodePath.join(RUNTIME_DIR, "pyodide-substitution-matrix.json"), "utf8");
+  const matrix = JSON.parse(raw) as {
+    forbidden_imports: Record<string, { prefer: string[] }>;
+    forbidden_binaries: Record<string, string>;
+    patterns: Array<{ task: string; bad: string; good: string }>;
+  };
+  assert.ok(matrix.forbidden_imports.requests?.prefer.includes("webagent.http"));
+  assert.ok(matrix.forbidden_binaries.soffice);
+  assert.ok(matrix.patterns.some((p) => /ZIP/i.test(p.task)));
+  assert.ok(matrix.patterns.length >= 6);
+});
+
+test("capabilities manifest references substitution matrix file", async () => {
+  const raw = await fs.readFile(nodePath.join(RUNTIME_DIR, "pyodide-capabilities.json"), "utf8");
+  const manifest = JSON.parse(raw) as { substitution_matrix: string };
+  const matrixPath = nodePath.join(RUNTIME_DIR, manifest.substitution_matrix);
+  await fs.access(matrixPath);
+});

--- a/tests/pyodide-preflight-corpus.test.ts
+++ b/tests/pyodide-preflight-corpus.test.ts
@@ -1,0 +1,103 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import nodePath from "node:path";
+
+import { preflightPython } from "../src/agent/runtime/tools/python-preflight.js";
+
+const FIXTURE_DIR = nodePath.join(process.cwd(), "tests/pyodide/fixtures/preflight");
+
+type PreflightCase = {
+  id: string;
+  file: string;
+  expect: "pass" | "block";
+  auto_packages?: string[];
+  auto_packages_includes?: string[];
+  auto_packages_excludes?: string[];
+  micropip_packages?: string[];
+  must_warn?: string[];
+  must_not_warn?: string[];
+  block_match?: string[];
+};
+
+function warnText(warnings: string[]): string {
+  return warnings.join("\n");
+}
+
+function assertWarnPatterns(warnings: string[], patterns: string[], label: string) {
+  const text = warnText(warnings);
+  for (const pattern of patterns) {
+    assert.match(text, new RegExp(pattern, "i"), `${label}: expected warning matching /${pattern}/`);
+  }
+}
+
+function assertNoWarnPatterns(warnings: string[], patterns: string[], label: string) {
+  const text = warnText(warnings);
+  for (const pattern of patterns) {
+    assert.doesNotMatch(
+      text,
+      new RegExp(pattern, "i"),
+      `${label}: should not warn matching /${pattern}/`
+    );
+  }
+}
+
+test("pyodide preflight fixture corpus", async (t) => {
+  const raw = await fs.readFile(nodePath.join(FIXTURE_DIR, "manifest.json"), "utf8");
+  const cases = JSON.parse(raw) as PreflightCase[];
+  assert.ok(cases.length >= 30, "corpus should cover common agent Python patterns");
+
+  for (const entry of cases) {
+    await t.test(entry.id, async () => {
+      const source = await fs.readFile(nodePath.join(FIXTURE_DIR, entry.file), "utf8");
+      const pre = preflightPython(source);
+
+      if (entry.expect === "block") {
+        assert.ok(pre.block, `${entry.id} should be blocked`);
+        for (const fragment of entry.block_match || []) {
+          assert.match(pre.block!, new RegExp(fragment, "i"), `${entry.id} block message`);
+        }
+        return;
+      }
+
+      assert.equal(pre.block, undefined, `${entry.id} should pass preflight: ${pre.block}`);
+
+      if (entry.auto_packages) {
+        assert.deepEqual(
+          [...pre.autoPackages].sort(),
+          [...entry.auto_packages].sort(),
+          `${entry.id} auto_packages`
+        );
+      }
+      if (entry.auto_packages_includes) {
+        for (const pkg of entry.auto_packages_includes) {
+          assert.ok(
+            pre.autoPackages.some((p) => p.toLowerCase() === pkg.toLowerCase()),
+            `${entry.id} should auto-load ${pkg}`
+          );
+        }
+      }
+      if (entry.auto_packages_excludes) {
+        for (const pkg of entry.auto_packages_excludes) {
+          assert.ok(
+            !pre.autoPackages.some((p) => p.toLowerCase() === pkg.toLowerCase()),
+            `${entry.id} should not auto-load ${pkg}`
+          );
+        }
+      }
+      if (entry.micropip_packages) {
+        assert.deepEqual(
+          [...pre.micropipPackages].sort(),
+          [...entry.micropip_packages].sort(),
+          `${entry.id} micropip_packages`
+        );
+      }
+      if (entry.must_warn?.length) {
+        assertWarnPatterns(pre.warnings, entry.must_warn, entry.id);
+      }
+      if (entry.must_not_warn?.length) {
+        assertNoWarnPatterns(pre.warnings, entry.must_not_warn, entry.id);
+      }
+    });
+  }
+});

--- a/tests/pyodide/fixtures/preflight/import-bs4.py
+++ b/tests/pyodide/fixtures/preflight/import-bs4.py
@@ -1,0 +1,2 @@
+from bs4 import BeautifulSoup
+BeautifulSoup("<p>x</p>", "html.parser")

--- a/tests/pyodide/fixtures/preflight/import-cv2.py
+++ b/tests/pyodide/fixtures/preflight/import-cv2.py
@@ -1,0 +1,1 @@
+import cv2

--- a/tests/pyodide/fixtures/preflight/import-directus.py
+++ b/tests/pyodide/fixtures/preflight/import-directus.py
@@ -1,0 +1,1 @@
+from directus import DirectusClient

--- a/tests/pyodide/fixtures/preflight/import-docx.py
+++ b/tests/pyodide/fixtures/preflight/import-docx.py
@@ -1,0 +1,2 @@
+import docx
+doc = docx.Document()

--- a/tests/pyodide/fixtures/preflight/import-feedparser.py
+++ b/tests/pyodide/fixtures/preflight/import-feedparser.py
@@ -1,0 +1,2 @@
+import feedparser
+feedparser.parse("<rss></rss>")

--- a/tests/pyodide/fixtures/preflight/import-numpy.py
+++ b/tests/pyodide/fixtures/preflight/import-numpy.py
@@ -1,0 +1,2 @@
+import numpy as np
+print(np.array([1, 2]).sum())

--- a/tests/pyodide/fixtures/preflight/import-openpyxl.py
+++ b/tests/pyodide/fixtures/preflight/import-openpyxl.py
@@ -1,0 +1,2 @@
+from openpyxl import Workbook
+wb = Workbook()

--- a/tests/pyodide/fixtures/preflight/import-pdf2image.py
+++ b/tests/pyodide/fixtures/preflight/import-pdf2image.py
@@ -1,0 +1,1 @@
+from pdf2image import convert_from_path

--- a/tests/pyodide/fixtures/preflight/import-pillow.py
+++ b/tests/pyodide/fixtures/preflight/import-pillow.py
@@ -1,0 +1,1 @@
+from PIL import Image

--- a/tests/pyodide/fixtures/preflight/import-playwright.py
+++ b/tests/pyodide/fixtures/preflight/import-playwright.py
@@ -1,0 +1,1 @@
+from playwright.sync_api import sync_playwright

--- a/tests/pyodide/fixtures/preflight/import-psycopg2.py
+++ b/tests/pyodide/fixtures/preflight/import-psycopg2.py
@@ -1,0 +1,1 @@
+import psycopg2

--- a/tests/pyodide/fixtures/preflight/import-pypdf.py
+++ b/tests/pyodide/fixtures/preflight/import-pypdf.py
@@ -1,0 +1,1 @@
+from pypdf import PdfReader

--- a/tests/pyodide/fixtures/preflight/import-requests.py
+++ b/tests/pyodide/fixtures/preflight/import-requests.py
@@ -1,0 +1,2 @@
+import requests
+requests.get("https://api.example.com/x")

--- a/tests/pyodide/fixtures/preflight/import-selenium.py
+++ b/tests/pyodide/fixtures/preflight/import-selenium.py
@@ -1,0 +1,1 @@
+from selenium import webdriver

--- a/tests/pyodide/fixtures/preflight/import-torch.py
+++ b/tests/pyodide/fixtures/preflight/import-torch.py
@@ -1,0 +1,1 @@
+import torch

--- a/tests/pyodide/fixtures/preflight/import-wikipedia.py
+++ b/tests/pyodide/fixtures/preflight/import-wikipedia.py
@@ -1,0 +1,2 @@
+import wikipedia
+wikipedia.search("test")

--- a/tests/pyodide/fixtures/preflight/import-yaml.py
+++ b/tests/pyodide/fixtures/preflight/import-yaml.py
@@ -1,0 +1,2 @@
+import yaml
+yaml.safe_load("k: v\n")

--- a/tests/pyodide/fixtures/preflight/ld-preload-ctypes.py
+++ b/tests/pyodide/fixtures/preflight/ld-preload-ctypes.py
@@ -1,0 +1,3 @@
+import os, ctypes
+os.environ["LD_PRELOAD"] = "/tmp/shim.so"
+lib = ctypes.CDLL("/tmp/shim.so")

--- a/tests/pyodide/fixtures/preflight/manifest.json
+++ b/tests/pyodide/fixtures/preflight/manifest.json
@@ -1,0 +1,58 @@
+[
+  {"id": "stdlib-json", "file": "stdlib-json.py", "expect": "pass"},
+  {"id": "stdlib-csv-pathlib", "file": "stdlib-csv-pathlib.py", "expect": "pass"},
+  {"id": "stdlib-zipfile", "file": "stdlib-zipfile.py", "expect": "pass"},
+  {"id": "stdlib-hashlib", "file": "stdlib-hashlib.py", "expect": "pass"},
+  {"id": "stdlib-re-html", "file": "stdlib-re-html.py", "expect": "pass"},
+  {"id": "stdlib-datetime", "file": "stdlib-datetime.py", "expect": "pass"},
+  {
+    "id": "webagent-http-import",
+    "file": "webagent-http-import.py",
+    "expect": "pass",
+    "must_not_warn": ["Unknown imports.*webagent"]
+  },
+  {"id": "import-docx", "file": "import-docx.py", "expect": "pass", "auto_packages": ["python-docx"]},
+  {"id": "import-openpyxl", "file": "import-openpyxl.py", "expect": "pass", "auto_packages": ["openpyxl"]},
+  {"id": "import-pypdf", "file": "import-pypdf.py", "expect": "pass", "auto_packages": ["pypdf"]},
+  {"id": "import-pillow", "file": "import-pillow.py", "expect": "pass", "auto_packages": ["Pillow"]},
+  {"id": "import-numpy", "file": "import-numpy.py", "expect": "pass", "auto_packages": ["numpy"]},
+  {"id": "import-bs4", "file": "import-bs4.py", "expect": "pass", "auto_packages": ["beautifulsoup4"]},
+  {"id": "import-yaml", "file": "import-yaml.py", "expect": "pass", "auto_packages": ["pyyaml"]},
+  {
+    "id": "import-feedparser",
+    "file": "import-feedparser.py",
+    "expect": "pass",
+    "micropip_packages": ["feedparser"]
+  },
+  {
+    "id": "office-multi-import",
+    "file": "office-multi-import.py",
+    "expect": "pass",
+    "auto_packages_includes": ["openpyxl", "Pillow", "numpy"]
+  },
+  {"id": "subprocess-python-ok", "file": "subprocess-python-ok.py", "expect": "pass"},
+  {"id": "urllib-urlopen", "file": "urllib-urlopen.py", "expect": "pass", "must_warn": ["urllib"]},
+  {"id": "import-requests", "file": "import-requests.py", "expect": "pass", "must_warn": ["requests"]},
+  {"id": "raw-socket", "file": "raw-socket.py", "expect": "pass", "must_warn": ["socket"]},
+  {
+    "id": "sys-stdout-reconfigure",
+    "file": "sys-stdout-reconfigure.py",
+    "expect": "pass",
+    "must_warn": ["reconfigure"]
+  },
+  {"id": "ld-preload-ctypes", "file": "ld-preload-ctypes.py", "expect": "pass", "must_warn": ["LD_PRELOAD"]},
+  {"id": "unknown-import", "file": "unknown-import.py", "expect": "pass", "must_warn": ["Unknown imports"]},
+  {"id": "subprocess-soffice", "file": "subprocess-soffice.py", "expect": "block", "block_match": ["soffice"]},
+  {"id": "subprocess-git", "file": "subprocess-git.py", "expect": "block", "block_match": ["git"]},
+  {"id": "os-system-tesseract", "file": "os-system-tesseract.py", "expect": "block", "block_match": ["tesseract"]},
+  {"id": "subprocess-pdftoppm", "file": "subprocess-pdftoppm.py", "expect": "block", "block_match": ["pdftoppm"]},
+  {"id": "shutil-which-gcc", "file": "shutil-which-gcc.py", "expect": "block", "block_match": ["gcc"]},
+  {"id": "import-pdf2image", "file": "import-pdf2image.py", "expect": "block", "block_match": ["pdf2image"]},
+  {"id": "import-playwright", "file": "import-playwright.py", "expect": "block", "block_match": ["playwright"]},
+  {"id": "import-torch", "file": "import-torch.py", "expect": "block", "block_match": ["torch"]},
+  {"id": "import-psycopg2", "file": "import-psycopg2.py", "expect": "block", "block_match": ["psycopg2"]},
+  {"id": "import-wikipedia", "file": "import-wikipedia.py", "expect": "block", "block_match": ["Wikipedia"]},
+  {"id": "import-directus", "file": "import-directus.py", "expect": "block", "block_match": ["directus"]},
+  {"id": "import-selenium", "file": "import-selenium.py", "expect": "block", "block_match": ["selenium"]},
+  {"id": "import-cv2", "file": "import-cv2.py", "expect": "block", "block_match": ["cv2"]}
+]

--- a/tests/pyodide/fixtures/preflight/office-multi-import.py
+++ b/tests/pyodide/fixtures/preflight/office-multi-import.py
@@ -1,0 +1,3 @@
+from openpyxl import Workbook
+from PIL import Image
+import numpy as np

--- a/tests/pyodide/fixtures/preflight/os-system-tesseract.py
+++ b/tests/pyodide/fixtures/preflight/os-system-tesseract.py
@@ -1,0 +1,2 @@
+import os
+os.system("tesseract in.png out")

--- a/tests/pyodide/fixtures/preflight/raw-socket.py
+++ b/tests/pyodide/fixtures/preflight/raw-socket.py
@@ -1,0 +1,2 @@
+import socket
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/tests/pyodide/fixtures/preflight/shutil-which-gcc.py
+++ b/tests/pyodide/fixtures/preflight/shutil-which-gcc.py
@@ -1,0 +1,2 @@
+import shutil
+shutil.which("gcc")

--- a/tests/pyodide/fixtures/preflight/stdlib-csv-pathlib.py
+++ b/tests/pyodide/fixtures/preflight/stdlib-csv-pathlib.py
@@ -1,0 +1,5 @@
+import csv, io
+from pathlib import Path
+buf = io.StringIO("a,b\n1,2\n")
+rows = list(csv.reader(buf))
+Path("out").mkdir(exist_ok=True)

--- a/tests/pyodide/fixtures/preflight/stdlib-datetime.py
+++ b/tests/pyodide/fixtures/preflight/stdlib-datetime.py
@@ -1,0 +1,2 @@
+from datetime import datetime, timezone
+print(datetime.now(timezone.utc).isoformat())

--- a/tests/pyodide/fixtures/preflight/stdlib-hashlib.py
+++ b/tests/pyodide/fixtures/preflight/stdlib-hashlib.py
@@ -1,0 +1,2 @@
+import hashlib
+print(hashlib.sha256(b"x").hexdigest())

--- a/tests/pyodide/fixtures/preflight/stdlib-json.py
+++ b/tests/pyodide/fixtures/preflight/stdlib-json.py
@@ -1,0 +1,2 @@
+import json
+print(json.dumps({"ok": True}))

--- a/tests/pyodide/fixtures/preflight/stdlib-re-html.py
+++ b/tests/pyodide/fixtures/preflight/stdlib-re-html.py
@@ -1,0 +1,3 @@
+import re, html
+m = re.search(r"(\d+)", "id=42")
+print(html.escape("<tag>"))

--- a/tests/pyodide/fixtures/preflight/stdlib-zipfile.py
+++ b/tests/pyodide/fixtures/preflight/stdlib-zipfile.py
@@ -1,0 +1,5 @@
+import zipfile
+from pathlib import Path
+out = Path("bundle.zip")
+with zipfile.ZipFile(out, "w") as zf:
+    zf.writestr("a.txt", "hi")

--- a/tests/pyodide/fixtures/preflight/subprocess-git.py
+++ b/tests/pyodide/fixtures/preflight/subprocess-git.py
@@ -1,0 +1,2 @@
+import subprocess
+subprocess.run(["git", "status"], capture_output=True)

--- a/tests/pyodide/fixtures/preflight/subprocess-pdftoppm.py
+++ b/tests/pyodide/fixtures/preflight/subprocess-pdftoppm.py
@@ -1,0 +1,2 @@
+import subprocess
+subprocess.run("pdftoppm in.pdf out", shell=True)

--- a/tests/pyodide/fixtures/preflight/subprocess-python-ok.py
+++ b/tests/pyodide/fixtures/preflight/subprocess-python-ok.py
@@ -1,0 +1,2 @@
+import subprocess
+subprocess.run(["python3", "-c", "print(1)"])

--- a/tests/pyodide/fixtures/preflight/subprocess-soffice.py
+++ b/tests/pyodide/fixtures/preflight/subprocess-soffice.py
@@ -1,0 +1,2 @@
+import subprocess
+subprocess.run(["soffice", "--headless", "--convert-to", "pdf", "doc.docx"])

--- a/tests/pyodide/fixtures/preflight/sys-stdout-reconfigure.py
+++ b/tests/pyodide/fixtures/preflight/sys-stdout-reconfigure.py
@@ -1,0 +1,2 @@
+import sys
+sys.stdout.reconfigure(line_buffering=True)

--- a/tests/pyodide/fixtures/preflight/unknown-import.py
+++ b/tests/pyodide/fixtures/preflight/unknown-import.py
@@ -1,0 +1,1 @@
+import totally_fictional_sdk_xyz

--- a/tests/pyodide/fixtures/preflight/urllib-urlopen.py
+++ b/tests/pyodide/fixtures/preflight/urllib-urlopen.py
@@ -1,0 +1,2 @@
+import urllib.request
+urllib.request.urlopen("https://example.com")

--- a/tests/pyodide/fixtures/preflight/webagent-http-import.py
+++ b/tests/pyodide/fixtures/preflight/webagent-http-import.py
@@ -1,0 +1,2 @@
+import webagent.http as http
+print(http)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Phase 1 of the Pyodide test and agent-contract plan: explicit runtime capabilities, a bundled codegen skill, a substitution matrix, and a 36-case static preflight corpus wired into CI via `npm test`.

## Changes

- **`src/runtimes/webcontainer/pyodide-capabilities.json`** — Machine-readable WASM runtime contract (version synced to `PYODIDE_VERSION`).
- **`src/runtimes/webcontainer/pyodide-substitution-matrix.json`** — Forbidden imports/binaries and good/bad patterns for common agent tasks.
- **`src/capabilities/skills/pyodide-runtime/SKILL.md`** — Bundled skill with full Pyodide execution contract for `run_python` codegen.
- **`tests/pyodide/fixtures/preflight/`** — 36 agent-shaped Python snippets + `manifest.json` driving corpus tests.
- **`tests/pyodide-preflight-corpus.test.ts`** / **`tests/pyodide-manifest.test.ts`** — Regression tests for preflight + manifest integrity.
- **Routing** — Capability router Python route → `pyodide-runtime`; `run_python` tool description nudges `skill_view` first; cross-links in `browser-runtime-map` and `imported-skill-compat`.

## Testing

- `npx tsx --test tests/pyodide-manifest.test.ts tests/pyodide-preflight-corpus.test.ts tests/python-preflight.test.ts` — pass
- `npx tsx --test tests/bundled-skills-coverage.test.ts` — pass (new `pyodide-runtime` skill)
- `npx tsc -b --noEmit` — pass

## Follow-up (Phase 2)

- `scripts/pyodide-harness.mjs` for real WASM execution of runtime fixtures
- Optional Playwright `run_python` E2E
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b43b8cfc-04eb-4afa-a392-3c629fa69411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b43b8cfc-04eb-4afa-a392-3c629fa69411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

