### PR TITLE
fix: align tools and skills signaling after autonomous MCP

### DIFF
--- a/src/agent/adapter.ts
+++ b/src/agent/adapter.ts
@@ -65,7 +65,6 @@ import runtimeClarifySlashSource from "../../dist/agent-runtime/clarify-slash.js
 import runtimeFindSkillsSlashSource from "../../dist/agent-runtime/find-skills-slash.js?raw";
 import runtimeWikiSlashSource from "../../dist/agent-runtime/wiki-slash.js?raw";
 import runtimeSlashRoutingSource from "../../dist/agent-runtime/slash-routing.js?raw";
-import runtimeMcpSlashSource from "../../dist/agent-runtime/mcp-slash.js?raw";
 import runtimeMcpConfigSource from "../../dist/agent-runtime/mcp-config.js?raw";
 import runtimeMcpRegistrySource from "../../dist/agent-runtime/mcp-registry.js?raw";
 import runtimeTerminalFormatSource from "../../dist/agent-runtime/terminal-format.js?raw";
@@ -533,7 +532,6 @@ async function writeRuntimeSources(profileId: string): Promise<void> {
   await emulator.fs.writeFile(`${webagentDir}/find-skills-slash.js`, runtimeFindSkillsSlashSource);
   await emulator.fs.writeFile(`${webagentDir}/wiki-slash.js`, runtimeWikiSlashSource);
   await emulator.fs.writeFile(`${webagentDir}/slash-routing.js`, runtimeSlashRoutingSource);
-  await emulator.fs.writeFile(`${webagentDir}/mcp-slash.js`, runtimeMcpSlashSource);
   await emulator.fs.writeFile(`${webagentDir}/mcp-config.js`, runtimeMcpConfigSource);
   await emulator.fs.writeFile(`${webagentDir}/mcp-registry.js`, runtimeMcpRegistrySource);
   await emulator.fs.writeFile(`${webagentDir}/terminal-format.js`, runtimeTerminalFormatSource);

--- a/src/agent/runtime/bootstrap.ts
+++ b/src/agent/runtime/bootstrap.ts
@@ -64,7 +64,7 @@ import { buildToolRowsFromCatalog } from "./slash-command-views.js";
 import { formatHelpForSurface, runSkillsSlashCommand } from "./channel-outbound.js";
 import { SLASH_COMMANDS } from "./commands.js";
 import { parseLocalSlashCommand, resolveSlashUserMessage } from "./slash-routing.js";
-import { discoverMcpOnStartup, runMcpSlashCommand, shutdownMcpOnExit } from "./mcp-slash.js";
+import { discoverMcpOnStartup, shutdownMcpOnExit } from "./mcp-registry.js";
 import {
   compactHistory,
   formatCompactionNotice,
@@ -469,15 +469,6 @@ export async function main() {
     }
     if (input === "/skills" || input.startsWith("/skills ")) {
       await handleSkillsCommand(input);
-      continue;
-    }
-    const localSlash = parseLocalSlashCommand(input);
-    if (localSlash.kind === "reload_mcp") {
-      await runMcpSlashCommand("/reload-mcp");
-      continue;
-    }
-    if (localSlash.kind === "mcp") {
-      await runMcpSlashCommand(localSlash.input);
       continue;
     }
     if (input === "/stop") {

--- a/src/agent/runtime/capability-router.ts
+++ b/src/agent/runtime/capability-router.ts
@@ -5,7 +5,7 @@ export type CapabilityRoute = {
   skill?: string;
   tools: string[];
   avoid?: string;
-  /** Show even when deferred tools are not yet active (skill_view unlocks them). */
+  /** Show even when listed tools are not in the active schema (e.g. dynamic mcp_*). skill_view unlocks deferred policy-group tools. */
   alwaysShow?: boolean;
 };
 
@@ -61,8 +61,9 @@ export const CAPABILITY_ROUTES: CapabilityRoute[] = [
   {
     need: "DOM click/type automation",
     skill: "imported-skill-compat",
-    tools: ["tool_search", "tool_activate"],
-    avoid: "web_fetch for clicks; use configured mcp_* browser tools when listed in the capability index",
+    tools: ["mcp_*"],
+    alwaysShow: true,
+    avoid: "web_fetch for clicks; call configured mcp_* tools from ## MCP in the Tool capability index",
   },
   {
     need: "JS-heavy page as text",

--- a/src/agent/runtime/tool-capability-index.ts
+++ b/src/agent/runtime/tool-capability-index.ts
@@ -112,14 +112,14 @@ function appendMcpSection(
 
     const header = `## MCP (${server})`;
     if (header.length + 1 > budget.remaining) {
-      lines.push(`- … +${tools.length} MCP tool(s) on ${server} (tool_search "mcp")`);
+      lines.push(`- … +${tools.length} MCP tool(s) on ${server} (see ## MCP in index)`);
       return;
     }
     lines.push(header);
     budget.remaining -= header.length + 1;
 
     if (tools.length > MCP_TOOLS_LIST_CAP) {
-      const summary = `- [deferred] ${tools.length} tools (e.g. ${tools.slice(0, 3).join(", ")}, …) — tool_search "${server}" then tool_activate`;
+      const summary = `- [active] ${tools.length} mcp_* tools (e.g. ${tools.slice(0, 3).join(", ")}, …) — call by exact name`;
       if (summary.length + 1 <= budget.remaining) {
         lines.push(summary);
         budget.remaining -= summary.length + 1;
@@ -154,10 +154,10 @@ export function buildToolCapabilityIndexBlock(opts: BuildToolCapabilityIndexOpts
   const mcpCount = Object.keys(catalog).filter((n) => n.startsWith("mcp_") && catalog[n]).length;
   const lines: string[] = [
     "# Tool capability index",
-    "All tools below exist in this agent. **Active** = callable now. **Deferred** = use `tool_search` then `tool_activate` before calling.",
+    "All tools below exist in this agent. **Active** = callable now. **Deferred** = policy-group or hidden-alias tools — use `tool_search` then `tool_activate` before calling (not for `mcp_*`).",
     mcpCount
-      ? `**MCP:** ${mcpCount} registered tool(s) under ## MCP below (\`mcp_*\` integrations). \`list_dir\`/\`find_files\`/\`tree\` are built-in browse aliases — not MCP.`
-      : "**MCP:** none registered yet — `/mcp use <url>` then `/reload-mcp` (browser tab open).",
+      ? `**MCP:** ${mcpCount} registered tool(s) under ## MCP below (\`mcp_*\` integrations, active when configured). \`list_dir\`/\`find_files\`/\`tree\` are built-in browse aliases — not MCP.`
+      : "**MCP:** none registered yet — add servers in `.webagent/mcp-servers.json` (and secrets in `.webagent/mcp-secrets.json`), then restart the profile.",
   ];
   const budget = { remaining: toolIndexCharBudget() - lines.join("\n").length - 2 };
 

--- a/src/agent/runtime/tools/builtins/tool_activate.ts
+++ b/src/agent/runtime/tools/builtins/tool_activate.ts
@@ -20,12 +20,12 @@ export default defineTool({
   emoji: "🔓",
   toolGroup: "core",
   description:
-    "Activate a deferred tool (usually MCP) for the next agent round in this turn. " +
-    "Call `tool_search` first, then `tool_activate` with the exact tool name, then call the tool on the following round.",
+    "Activate a deferred policy-group or hidden-alias tool for the next agent round in this turn. " +
+    "Call `tool_search` first, then `tool_activate` with the exact tool name, then call the tool on the following round. Not for `mcp_*` (already active when configured).",
   inputSchema: {
     type: "object",
     properties: {
-      name: { type: "string", description: "Exact deferred tool name (e.g. mcp_github_create_issue)." },
+      name: { type: "string", description: "Exact deferred tool name (e.g. cron_register, list_dir)." },
     },
     required: ["name"],
     additionalProperties: false,

--- a/src/agent/runtime/tools/builtins/tool_search.ts
+++ b/src/agent/runtime/tools/builtins/tool_search.ts
@@ -17,9 +17,9 @@ export default defineTool({
   emoji: "🔍",
   toolGroup: "core",
   description:
-    "Search deferred tools (MCP `mcp_*` integrations and hidden aliases) not in the active schema. " +
-    "For MCP capabilities use query `mcp` (not empty — empty omits browse aliases but may miss MCP). " +
-    "Read ## MCP in the Tool capability index first. Use before `tool_activate`.",
+    "Search deferred tools (policy-group tools and hidden browse aliases like list_dir/find_files/tree) not in the active schema. " +
+    "`mcp_*` tools are active when configured — see ## MCP in the Tool capability index; do not use this tool to discover MCP. " +
+    "Use before `tool_activate`.",
   inputSchema: {
     type: "object",
     properties: {

--- a/src/agent/runtime/tools/tinyfish-fetch.ts
+++ b/src/agent/runtime/tools/tinyfish-fetch.ts
@@ -21,7 +21,7 @@ export function spaShellPageRecoveryHint(text: unknown, url?: string): string | 
     }
     if (/\/items\/|\/collections\/|\/graphql|\/mcp\b|\/server\/|\/auth\//i.test(u.pathname)) {
       return (
-        `${hostNote}This URL looks like an API path but returned HTML — add Authorization (Bearer) on web_fetch/web_post, or configure Directus MCP in `.webagent/mcp-servers.json`. Do not treat HTTP 200 here as unreachable or retry without auth.`
+        `${hostNote}This URL looks like an API path but returned HTML — add Authorization (Bearer) on web_fetch/web_post, or configure Directus MCP in .webagent/mcp-servers.json. Do not treat HTTP 200 here as unreachable or retry without auth.`
       );
     }
   } catch {

--- a/src/agent/runtime/tools/tool-search-tools.ts
+++ b/src/agent/runtime/tools/tool-search-tools.ts
@@ -17,24 +17,18 @@ export async function searchDeferredTools(
   catalogOverride?: Record<string, { description?: string; llmVisible?: boolean } | undefined>
 ): Promise<Array<{ name: string; description: string; server?: string }>> {
   const q = String(query || "").trim().toLowerCase();
-  const mcpIntent = !q || /\bmcp\b|capabilit|integrat|directus|server/.test(q);
   const catalog =
     catalogOverride ?? (await import("./registry.js").then((m) => m.loadToolCatalog()));
   const matches: Array<{ name: string; description: string; server?: string; score: number }> = [];
   for (const [name, meta] of Object.entries(catalog)) {
     if (activeToolNames.has(name)) continue;
     if (!isDeferredCatalogTool(name, meta)) continue;
-    const isMcp = String(name).startsWith("mcp_");
-    if (!q && isHiddenBrowseAlias(name)) continue;
     const description = String(meta?.description || "");
     const haystack = `${name} ${description}`.toLowerCase();
     let score = 0;
     if (!q) {
-      score = isMcp ? 3 : 1;
-    } else if (isMcp && mcpIntent) {
-      score += 5;
-      if (name.toLowerCase().includes(q)) score += 2;
-      else if (haystack.includes(q)) score += 1;
+      if (!isHiddenBrowseAlias(name)) continue;
+      score = 1;
     } else if (name.toLowerCase().includes(q)) {
       score += 3;
     } else if (haystack.includes(q)) {
@@ -51,7 +45,7 @@ export async function searchDeferredTools(
     });
   }
   matches.sort((a, b) => {
-    const tier = (n: string) => (n.startsWith("mcp_") ? 2 : isHiddenBrowseAlias(n) ? 0 : 1);
+    const tier = (n: string) => (isHiddenBrowseAlias(n) ? 0 : 1);
     return b.score - a.score || tier(b.name) - tier(a.name) || a.name.localeCompare(b.name);
   });
   return matches.slice(0, Math.max(1, Math.min(25, limit))).map(({ score: _score, ...row }) => row);

--- a/src/capabilities/skills/http-api/SKILL.md
+++ b/src/capabilities/skills/http-api/SKILL.md
@@ -67,7 +67,7 @@ Canonical procedure for **REST GET** (`web_fetch`) and **HTTP writes** (`web_pos
 
 ## Relation to other skills
 
-- Tool picker (shell vs HTTP): **`browser-runtime-map`**. MCP integrations: configure via `/mcp`; names appear in the system **Tool capability index** — activate with `tool_search` / `tool_activate` before use.
+- Tool picker (shell vs HTTP): **`browser-runtime-map`**. MCP integrations: `.webagent/mcp-servers.json` (+ secrets); `mcp_*` tools register at profile startup and appear as **active** under ## MCP in the **Tool capability index** — call them directly (not via `tool_search` / `tool_activate`).
 - Python scripts: **`run_python`** when Pyodide-compatible. Secrets: **`memory-layers`**.
 - **Imported skills own endpoints** — call `skill_view` on the imported skill first; use this skill for generic REST/GraphQL mechanics.
 
@@ -107,7 +107,7 @@ When `web_fetch` uses TinyFish (default when no `headers`) and markdown returns 
 
 - **HTTP 200 means the host responded** — not outage, not "unreachable", and not proof the REST API is broken.
 - That body is the **non-API UI shell** (no JS in TinyFish). Do **not** loop on the same admin/root URL or declare the site down.
-- **Do instead:** call documented REST paths (`/items/…`, `/collections/…`, `/server/info`, …) with `headers.Authorization: Bearer <token>`, `web_post` for writes, or `/mcp use <url>/mcp` for Directus MCP.
+- **Do instead:** call documented REST paths (`/items/…`, `/collections/…`, `/server/info`, …) with `headers.Authorization: Bearer <token>`, `web_post` for writes, or add the Directus MCP server in `.webagent/mcp-servers.json` and call `mcp_*` tools.
 
 Authenticated GET always passes `headers` → routes via `/api/proxy` (JSON), not TinyFish markdown.
 
@@ -115,12 +115,12 @@ Authenticated GET always passes `headers` → routes via `/api/proxy` (JSON), no
 
 Configure a Directus Streamable HTTP MCP endpoint (**the Web Agent page must be running** (Telegram messages already prove this — MCP failures are usually auth, remote server reachability, or an IPC bridge bug, not a closed tab):
 
-1. Bearer token in `.webagent/mcp-secrets.json` (`directus_token`) — saves bearer token in workspace (`.webagent/mcp-secrets.json`); works from Telegram without pasting the token into `/mcp use`.
-2. Server entry in `.webagent/mcp-servers.json` — Telegram: `/mcp@YourBot use …` (normalized automatically).
-3. Relaunch profile to discover tools if tools do not appear after save.
-4. Agent workflow: call `mcp_*` tools directly with exact tool name → call `mcp_<server>_<tool>`. MCP tools are **not** in the default LLM tool list.
+1. Bearer token in `.webagent/mcp-secrets.json` (`directus_token` or server-specific keys).
+2. Server entry in `.webagent/mcp-servers.json` (Streamable HTTP URL for Directus MCP).
+3. Restart the profile (or reload the workspace) so startup discovery registers `mcp_*` tools.
+4. Agent workflow: call `mcp_<server>_<tool>` by exact name from ## MCP in the Tool capability index — they are in the active tool schema when configured.
 
-If probe times out: open Web Agent in the browser, start the profile, then `/reload_mcp`. Config may already be saved as enabled.
+If probe times out: keep the Web Agent tab open, verify the remote MCP endpoint and auth, then restart the profile. Config may already be saved as enabled.
 
 Prefer MCP for CMS mutations when REST from the sandbox is blocked; prefer REST (`/items/…` + Bearer) when `headers` work.
 

--- a/src/capabilities/skills/imported-skill-compat/SKILL.md
+++ b/src/capabilities/skills/imported-skill-compat/SKILL.md
@@ -3,7 +3,7 @@ name: Imported Skill Compat
 description: Use when the user or agent installs a skill from skills.sh or GitHub — map WebFetch, Bash, Python, Playwright, and MCP references to Web Agent built-ins.
 version: 1.0.0
 category: bundled
-primary-tools: [skill_view, run_python, web_fetch, web_post, tool_search, tool_activate]
+primary-tools: [skill_view, run_python, web_fetch, web_post]
 tags: [skills, import, compatibility, skills.sh, webfetch, bash, python, playwright, mcp]
 triggers: [imported skill, skills.sh install, skill compat, WebFetch, agent-browser, playwright skill, remote skill mapping, after skill install]
 ---
@@ -21,7 +21,7 @@ triggers: [imported skill, skills.sh install, skill compat, WebFetch, agent-brow
 | Python HTTP (`urllib`, `requests`) | `webagent.http` inside `run_python`, or `web_fetch`/`web_post` for REST/CMS — **`http-api`** |
 | pip / native deps | No system pip; use Pyodide packages if available or replace the native dependency step |
 | agent-browser / Playwright | **Not available** — `web_fetch` + file tools |
-| MCP / CallMcpTool | configure `.webagent/mcp-servers.json`; call `mcp_*` tools directly next round |
+| MCP / CallMcpTool | configure `.webagent/mcp-servers.json` (+ `.webagent/mcp-secrets.json`); call `mcp_*` tools directly (active when configured) |
 | Rendered-fetch provider (JS-heavy pages) | `web_fetch` only — not DOM automation; optional backend for markdown text |
 
 **Non-negotiable:** After any remote install (`skill_manage import_url`, `skill_bulk_save`, `/skills install`), call `skill_view` on the installed slug and follow its **Web Agent execution (auto-appended)** section before tool fan-out. Check `script_warnings` in the `skill_view` result for per-file Pyodide preflight notes.

--- a/tests/tool-capability-index.test.ts
+++ b/tests/tool-capability-index.test.ts
@@ -114,13 +114,20 @@ test("MCP tools appear in index under default policy without explicit allow grou
     DEFAULT_TOOL_POLICY,
     {}
   );
+  const active = resolveInitialActiveToolNames(
+    policyNames,
+    ["read_file", mcpName],
+    DEFAULT_TOOL_POLICY,
+    {},
+    []
+  );
   const block = buildToolCapabilityIndexBlock({
     catalog,
     policyToolNames: policyNames,
-    activeToolNames: ["read_file"],
+    activeToolNames: active,
   });
   assert.match(block, /## MCP \(demo-server\)/);
-  assert.match(block, new RegExp(`\\[deferred\\] ${mcpName}`));
+  assert.match(block, new RegExp(`\\[active\\] ${mcpName}`));
 });
 
 test("MCP tools grouped under server header", () => {
@@ -134,13 +141,21 @@ test("MCP tools grouped under server header", () => {
     [mcpTools[1]]: { description: "[MCP:hub-aratech-ae-mcp] Read one item." },
     [mcpTools[2]]: { description: "[MCP:hub-aratech-ae-mcp] Create item." },
   });
+  const policyNames = resolvePolicyToolNames(["read_file", ...mcpTools], DEFAULT_TOOL_POLICY, {});
+  const active = resolveInitialActiveToolNames(
+    policyNames,
+    ["read_file", ...mcpTools],
+    DEFAULT_TOOL_POLICY,
+    {},
+    []
+  );
   const block = buildToolCapabilityIndexBlock({
     catalog,
-    policyToolNames: ["read_file", ...mcpTools],
-    activeToolNames: ["read_file"],
+    policyToolNames: policyNames,
+    activeToolNames: active,
   });
   assert.match(block, /## MCP \(hub-aratech-ae-mcp\)/);
-  assert.match(block, /\[deferred\] mcp_hub_aratech_ae_mcp_items_list/);
+  assert.match(block, /\[active\] mcp_hub_aratech_ae_mcp_items_list/);
 });
 
 test("budget truncation keeps MCP summary when many MCP tools", () => {

--- a/tests/tool-search.test.ts
+++ b/tests/tool-search.test.ts
@@ -6,9 +6,9 @@ import {
   searchDeferredTools,
 } from "../src/agent/runtime/tools/tool-search-tools.ts";
 
-test("isDeferredCatalogTool marks llmVisible false and mcp tools", () => {
+test("isDeferredCatalogTool marks llmVisible false but not mcp tools", () => {
   assert.equal(isDeferredCatalogTool("list_dir", { llmVisible: false }), true);
-  assert.equal(isDeferredCatalogTool("mcp_github_search", {}), true);
+  assert.equal(isDeferredCatalogTool("mcp_github_search", {}), false);
   assert.equal(isDeferredCatalogTool("read_file", {}), false);
 });
 
@@ -18,7 +18,7 @@ test("tool_activate schema requires name", async () => {
   assert.deepEqual(mod.default.inputSchema.required, ["name"]);
 });
 
-test("searchDeferredTools empty query returns mcp tools not browse aliases", async () => {
+test("searchDeferredTools empty query returns hidden browse aliases not mcp", async () => {
   const catalog = {
     list_dir: { description: "list one dir", llmVisible: false },
     find_files: { description: "find files", llmVisible: false },
@@ -26,17 +26,17 @@ test("searchDeferredTools empty query returns mcp tools not browse aliases", asy
     mcp_demo_server_items_read: { description: "[MCP:demo-server] Read item.", llmVisible: false },
   };
   const matches = await searchDeferredTools("", new Set(["read_file"]), 12, catalog);
-  assert.ok(matches.every((m) => m.name.startsWith("mcp_")));
+  assert.ok(matches.every((m) => isHiddenBrowseAlias(m.name)));
   assert.equal(matches.length, 2);
 });
 
-test("searchDeferredTools mcp query ranks mcp above browse aliases", async () => {
+test("searchDeferredTools mcp query does not return mcp tools", async () => {
   const catalog = {
     list_dir: { description: "list", llmVisible: false },
     mcp_hub_items_list: { description: "[MCP:hub] List.", llmVisible: false },
   };
   const matches = await searchDeferredTools("mcp", new Set(["read_file"]), 12, catalog);
-  assert.equal(matches[0]?.name, "mcp_hub_items_list");
+  assert.ok(matches.every((m) => !m.name.startsWith("mcp_")));
 });
 
 test("tool_search is in core tool group policy", async () => {

--- a/tests/web-http-tools.test.ts
+++ b/tests/web-http-tools.test.ts
@@ -97,7 +97,7 @@ test("guessedResourceRecoveryHint ignores shallow paths", () => {
 test("formatProxyTransportError adds MCP hint for Failed to fetch", () => {
   const msg = formatProxyTransportError("Failed to fetch", "https://hub.aratech.ae/items/posts");
   assert.match(msg, /\/api\/proxy/);
-  assert.match(msg, /\/mcp use/);
+  assert.match(msg, /mcp_\*/);
   assert.match(msg, /hub\.aratech\.ae/);
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After the autonomous MCP changes (MCP tools active at startup, slash commands removed), several layers still told the model to use `tool_search` / `tool_activate` for `mcp_*` or `/mcp use`. This PR makes **one consistent priority model** across the capability router, tool capability index, built-in tool descriptions, and bundled skills—without adding new tools or skills.

## Priority model (unchanged tool/skill count)

| Layer | Role |
|-------|------|
| **Capability router** | Task → hub skill (`skill_view`) → built-in tools |
| **`mcp_*`** | Active when configured; call directly (## MCP in index) |
| **`tool_search` / `tool_activate`** | Only deferred policy-group tools + hidden browse aliases (`list_dir`, `find_files`, `tree`) |
| **Skills** | Procedures via `skill_view`; `primary-tools` unlock deferred tools |

## Fixes

- **Capability router**: DOM automation route points at `mcp_*` + `imported-skill-compat`, not `tool_search`/`tool_activate`.
- **Tool capability index & builtins**: MCP labeled active; deferred flow explicitly excludes `mcp_*`.
- **`http-api` / `imported-skill-compat` skills**: Docs match autonomous MCP (config files + profile restart, no slash).
- **`spaShellPageRecoveryHint`**: Fixed nested backticks that threw at runtime and dropped API-path recovery text.
- **Bootstrap / adapter**: `discoverMcpOnStartup` from `mcp-registry`; removed dead `/mcp` handlers and missing `mcp-slash` embed.
- **`searchDeferredTools`**: Empty query lists hidden browse aliases again (not MCP).

## Verification

- `npm test` (801 pass)
- `npx tsc -b --noEmit`
- `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d297ae7-d084-40c1-9906-273b08cdecf5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d297ae7-d084-40c1-9906-273b08cdecf5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

