### PR TITLE
Skip web terminal output for Telegram channel turns

### DIFF
--- a/src/agent/runtime/channels/dispatcher.ts
+++ b/src/agent/runtime/channels/dispatcher.ts
@@ -499,6 +499,8 @@ export function createChannelInboundHandler(deps) {
           input: trimmed,
           ask: null,
           autoApprove: true,
+          skipTerminalOutput: true,
+          skipBackgroundReview: true,
           ...(channelMaxRounds != null ? { maxAgentRounds: channelMaxRounds } : {}),
           services: typeof sendDocument === "function"
             ? { sendDocument: (doc) => sendDocument(chatId, doc) }

--- a/src/agent/runtime/tools/context.ts
+++ b/src/agent/runtime/tools/context.ts
@@ -37,6 +37,7 @@ export type CreateToolContextInput = {
   ask?: Function | null;
   autoApprove?: boolean;
   onTranscript?: Function | null;
+  skipTerminalOutput?: boolean;
 };
 
 /**
@@ -56,6 +57,7 @@ export function createToolContext({
   ask = null,
   autoApprove = true,
   onTranscript = null,
+  skipTerminalOutput = false,
 }: CreateToolContextInput = {}) {
   const safeTimeout = Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : DEFAULT_TIMEOUT_MS;
   return Object.freeze({
@@ -71,6 +73,7 @@ export function createToolContext({
     ask,
     autoApprove,
     onTranscript,
+    skipTerminalOutput: skipTerminalOutput === true,
   });
 }
 

--- a/src/agent/runtime/tools/registry.ts
+++ b/src/agent/runtime/tools/registry.ts
@@ -387,9 +387,11 @@ async function writeToolStartTranscript(
   toolCatalog?: Record<string, { emoji?: string } | undefined>
 ) {
   const event = createToolStartTranscriptEvent({ name, argsPreview, argsPreviewTruncated });
-  process.stdout.write(
-    dim(`${formatToolStartTranscript({ ...event, toolCatalog })}\n`)
-  );
+  if (!ctx?.skipTerminalOutput) {
+    process.stdout.write(
+      dim(`${formatToolStartTranscript({ ...event, toolCatalog })}\n`)
+    );
+  }
   await emitTranscriptEvent(ctx, event, {
     tool: name,
     runId: ctx?.runId || null,
@@ -404,7 +406,9 @@ async function writeToolResultTranscript(
   const event = createToolResultTranscriptEvent({ name, status, error });
   const line = formatToolResultTranscript({ ...event, toolCatalog });
   const color = status === "error" ? red : status === "denied" ? dim : green;
-  process.stdout.write(color(`${line}\n`));
+  if (!ctx?.skipTerminalOutput) {
+    process.stdout.write(color(`${line}\n`));
+  }
   await emitTranscriptEvent(ctx, event, {
     tool: name,
     runId: ctx?.runId || null,

--- a/src/agent/runtime/tools/system-artifact-tools.ts
+++ b/src/agent/runtime/tools/system-artifact-tools.ts
@@ -202,9 +202,11 @@ export async function artifactPresentTool(args = {}, ctx) {
     };
   }
 
-  process.stdout.write(
-    `${ARTIFACT_PRESENT_START}${JSON.stringify(payload)}${ARTIFACT_PRESENT_END}\n`
-  );
+  if (!ctx?.skipTerminalOutput) {
+    process.stdout.write(
+      `${ARTIFACT_PRESENT_START}${JSON.stringify(payload)}${ARTIFACT_PRESENT_END}\n`
+    );
+  }
 
   if (typeof ctx?.services?.sendDocument === "function") {
     try {

--- a/src/agent/runtime/turn.ts
+++ b/src/agent/runtime/turn.ts
@@ -508,6 +508,7 @@ export async function agentTurn(
     },
     ask: typeof turnMeta?.ask === "function" ? turnMeta.ask : null,
     onTranscript: typeof turnMeta?.onTranscript === "function" ? turnMeta.onTranscript : null,
+    skipTerminalOutput: turnMeta?.skipTerminalOutput === true,
     autoApprove:
       typeof turnMeta?.autoApprove === "boolean"
         ? turnMeta.autoApprove
@@ -526,6 +527,8 @@ export async function agentTurn(
   const complexityEstimate = estimateTaskComplexity(originalUserInput);
   const maxAgentRounds = resolveMaxAgentRounds(turnMeta);
   const quietTurn = turnMeta?.quiet === true;
+  const skipTerminalOutput = turnMeta?.skipTerminalOutput === true;
+  const mirrorTerminal = !quietTurn && !skipTerminalOutput;
   const skipBackgroundReview = turnMeta?.skipBackgroundReview === true || turnMeta?.backgroundReview === true;
 
   if (!turnMeta?.backgroundReview && !turnMeta?.textOnly) {
@@ -686,7 +689,7 @@ export async function agentTurn(
       const combined = streamResult?.text || acc;
       const clarifyParsed = extractClarifyMarkers(combined);
       for (const block of clarifyParsed.blocks) {
-        process.stdout.write(block);
+        if (mirrorTerminal) process.stdout.write(block);
       }
       const clarifyEmitted = clarifyParsed.blocks.length > 0;
       const bodyForTools = clarifyParsed.visible;
@@ -750,16 +753,20 @@ export async function agentTurn(
         const rendered = visible.trim() ? renderMarkdownToAnsi(visible) : "";
         let branchBelowName = false;
         if (!turnHeaderPrinted) {
-          if (round > 1) process.stdout.write("\n");
-          process.stdout.write(`${bold(cyan(agentName))}\n`);
-          turnHeaderPrinted = true;
           branchBelowName = true;
-        } else if (round > 1) {
+          turnHeaderPrinted = true;
+          if (mirrorTerminal) {
+            if (round > 1) process.stdout.write("\n");
+            process.stdout.write(`${bold(cyan(agentName))}\n`);
+          }
+        } else if (mirrorTerminal && round > 1) {
           process.stdout.write("\n");
         }
         if (rendered) {
           const block = prefixBlock(rendered, branchBelowName);
-          await writeStdoutSmoothed(`${block}\n\n`);
+          if (mirrorTerminal) {
+            await writeStdoutSmoothed(`${block}\n\n`);
+          }
           await emitTranscriptEvent(
             turnMeta,
             createAssistantTranscriptEvent({
@@ -777,7 +784,7 @@ export async function agentTurn(
             visibleText: visible,
             renderedAnsi: rendered,
           });
-        } else if (clarifyEmitted) {
+        } else if (clarifyEmitted && mirrorTerminal) {
           await writeStdoutSmoothed(
             `${prefixBlock(dim("Choose an option in the panel above the input."), branchBelowName)}\n\n`
           );
@@ -805,13 +812,15 @@ export async function agentTurn(
           });
           await recordToolFailure(rejectedName).catch(() => {});
         }
-        process.stdout.write(
-          dim(
-            `▸ skipped ${rejected.length} invalid tool call(s): ${rejected
-              .map((r) => r.reason)
-              .join(", ")}\n`
-          )
-        );
+        if (mirrorTerminal) {
+          process.stdout.write(
+            dim(
+              `▸ skipped ${rejected.length} invalid tool call(s): ${rejected
+                .map((r) => r.reason)
+                .join(", ")}\n`
+            )
+          );
+        }
         await emitTranscriptEvent(
           turnMeta,
           createSystemLineTranscriptEvent({
@@ -1041,14 +1050,16 @@ export async function agentTurn(
             conv[conv.length - 1] = { role: "assistant", content: visible };
           }
           if (!quietTurn && visible.trim()) {
-            if (!turnHeaderPrinted) {
-              process.stdout.write(`${bold(cyan(agentName))}\n`);
-              turnHeaderPrinted = true;
-            } else {
-              process.stdout.write("\n");
+            if (mirrorTerminal) {
+              if (!turnHeaderPrinted) {
+                process.stdout.write(`${bold(cyan(agentName))}\n`);
+                turnHeaderPrinted = true;
+              } else {
+                process.stdout.write("\n");
+              }
+              const rendered = renderMarkdownToAnsi(visible);
+              await writeStdoutSmoothed(`${prefixBlock(rendered, false)}\n\n`);
             }
-            const rendered = renderMarkdownToAnsi(visible);
-            await writeStdoutSmoothed(`${prefixBlock(rendered, false)}\n\n`);
           }
         }
         await logDebugEvent("turn_completed", {
@@ -1094,7 +1105,9 @@ export async function agentTurn(
             code: before.code,
             count: before.count,
           });
-          process.stdout.write(dim(`▸ tool guardrail blocked ${tool.name}: ${before.message}\n`));
+          if (mirrorTerminal) {
+            process.stdout.write(dim(`▸ tool guardrail blocked ${tool.name}: ${before.message}\n`));
+          }
           continue;
         }
         runnableTools.push(tool);
@@ -1130,7 +1143,9 @@ export async function agentTurn(
           } else {
             result.result = guided;
           }
-          process.stdout.write(dim(`▸ tool guardrail ${after.code} (${tool.name})\n`));
+          if (mirrorTerminal) {
+            process.stdout.write(dim(`▸ tool guardrail ${after.code} (${tool.name})\n`));
+          }
           await logDebugEvent("tool_guardrail_warning", {
             round,
             tool: tool.name,
@@ -1314,7 +1329,7 @@ export async function agentTurn(
             run.final_visible_assistant_text = graceVisible;
             conv.push({ role: "assistant", content: graceVisible });
             const rendered = renderMarkdownToAnsi(graceVisible);
-            if (rendered) {
+            if (rendered && mirrorTerminal) {
               await writeStdoutSmoothed(`${prefixBlock(rendered, false)}\n\n`);
             }
             await emitTranscriptEvent(

--- a/tests/channel-dispatcher.test.ts
+++ b/tests/channel-dispatcher.test.ts
@@ -66,6 +66,8 @@ test("channel dispatcher sends tool notices and then the final answer", async ()
       },
       agentTurn: async (_history, _cfg, meta) => {
         assert.equal(meta.onToolCalls, undefined);
+        assert.equal(meta.skipTerminalOutput, true);
+        assert.equal(meta.skipBackgroundReview, true);
         await meta.onTranscript({
           type: "tool_start",
           name: "web_search",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Channel turns (Telegram and any future inbound channel) now pass `skipTerminalOutput: true` into `agentTurn`, so assistant replies, tool notices, guardrail lines, and artifact markers are **not** mirrored to `process.stdout` / the web xterm.
- Transcript delivery via `onTranscript` is unchanged — Telegram still receives tool progress and final answers.
- Channel turns also set `skipBackgroundReview: true` to avoid self-improvement sidecar turns writing to the terminal when the browser tab is unattended.

## Why

Long Telegram-only sessions previously duplicated every agent response into the web UI terminal, growing xterm buffer memory even when nobody was watching the browser tab. Keeping the tab open for the embedded runtime is still required, but terminal mirroring is not.

## Verification

- [x] `node --import tsx --test tests/channel-dispatcher.test.ts` (includes new assertions for `skipTerminalOutput` / `skipBackgroundReview`)
- [x] `npx tsc -b --noEmit`
- [ ] `npm run build` — fails on base branch too (`mcp-slash.js` missing from dist); unrelated to this change

## Notes

- Web UI REPL turns are unaffected; only inbound channel dispatcher turns skip terminal mirroring.
- If terminal mirroring for channels is ever needed again, it could be gated behind an env var at the dispatcher call site.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bd1b7365-d93e-424e-b23f-0c84528c632a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd1b7365-d93e-424e-b23f-0c84528c632a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

