### PR TITLE
Allow saving credentials in browser-local memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ Skills are reusable procedures stored as `SKILL.md` files. They let Web Agent sw
 
 | Slash command | Hub for |
 | --- | --- |
-| `/memory-layers` | Facts, session notes, wiki mirror, secret hygiene, `session_search` |
+| `/memory-layers` | Facts, session notes, wiki mirror, `session_search` |
 | `/browser-runtime-map` | WebContainer limits, shell failures, file layout |
 | `/http-api` | REST GET (`web_fetch`) and POST/GraphQL (`web_post`) — auth, query shapes, CMS patterns |
 | `/imported-skill-compat` | Imported skills from other hosts → Web Agent tools, including `run_python` |
@@ -512,7 +512,7 @@ Twenty-five personal-helper scenarios with copy-paste prompts, bundled skills, a
 | Delivery | Flowchart for a plan or report | `/chart` | `artifact_present` |
 | UX | Disambiguate a vague ask | `/clarify` | *(none)* |
 | Safety | Checkpoint before bulk delete | `/workspace-safety` | `list_dir`, `delete_file` |
-| Safety | Pasted API key / secret hygiene | `/memory-layers` | *(redaction; no secret persistence)* |
+| Safety | Pasted API key by mistake | `/artifact-delivery` | Redact in replies; save to memory only when user asks |
 | Meta | Improve Web Agent itself | `/web-agent-skill` | `read_file`, `grep`, `skill_manage`, `memory_save` |
 
 ## Quick Start

--- a/docs/test-prompts.md
+++ b/docs/test-prompts.md
@@ -41,7 +41,7 @@ Curated prompts for smoke and regression runs. Paste into the chat as-is; tweak 
 18. Explicitly invoke the **`memory-layers`** skill flow: summarize what layers exist in this codebase and outline when each should trigger (reference repo skill docs if accessible).
 19. Walk through **`systematic-debugging`**: hypothesis → smallest repro → instrumentation → rollback plan—applied to “terminal prompt never appears”.
 20. Use **`workspace-safety`** mindset: propose a harmless read-only checklist before destructive shell commands and refuse obviously unsafe requests (demonstrate with a hypothetical `rm -rf /`).
-21. Apply **`memory-layers`**: pretend I pasted a fake API key; show how you'd redact, rotate guidance, and what never to persist.
+21. Apply **`memory-layers`**: user asks to remember a fake API key — show `memory_save` with a snake_case key; if they only pasted it by mistake, redact and do not save unless they ask.
 22. Summarize **`clarify`**: draft 3 targeted questions you'd ask next if requirements are ambiguous—to stress-test narrowing behavior.
 
 ---

--- a/docs/use-cases-playbook.md
+++ b/docs/use-cases-playbook.md
@@ -32,7 +32,7 @@ Twenty-five copy-paste scenarios for getting real work done with Web Agent. Each
 | Delivery | Flowchart for a plan or report | `/chart` | `artifact_present` |
 | UX | Disambiguate a vague ask | `/clarify` | *(none)* |
 | Safety | Checkpoint before bulk delete | `/workspace-safety` | `list_dir`, `tree`, `delete_file` |
-| Safety | Pasted API key / secret hygiene | `/memory-layers` | *(redaction; no secret persistence)* |
+| Safety | Pasted API key by mistake | `/artifact-delivery` | Redact in replies; `memory_save` only when user asks |
 | Meta | Improve Web Agent itself | `/web-agent-skill` | `read_file`, `grep`, `skill_manage`, `memory_save` |
 
 ---
@@ -531,19 +531,19 @@ I want to delete everything under work/scratch/. List what's there with sizes, c
 </details>
 
 <details>
-<summary><strong>Pasted API key / secret hygiene</strong> — redact, never persist secrets</summary>
+<summary><strong>Pasted API key by mistake</strong> — redact in chat; save only if asked</summary>
 
-When you accidentally paste a key or ask to store secrets — rotate guidance, no `memory_save` for raw tokens.
+When you accidentally paste a key — redact it from replies and artifacts. Use `memory_save` only when the user explicitly asks you to remember it (browser-local storage).
 
 **Try this prompt:**
 
 ```
-I pasted this by mistake: sk-test-1234567890abcdef — redact it from your reply, tell me what you will NOT store, and how to rotate safely.
+I pasted this by mistake: sk-test-1234567890abcdef — redact it from your reply and tell me how to rotate safely. Do not save it unless I ask.
 ```
 
-**Bundled skills:** `/memory-layers`
+**Bundled skills:** `/artifact-delivery`, `/memory-layers`
 
-**Tools that fire:** *(redaction guidance; avoid `memory_save` for secrets)*
+**Tools that fire:** *(redaction guidance; optional `memory_save` when user requests)*
 
 </details>
 

--- a/src/agent/runtime/memory-guidance.ts
+++ b/src/agent/runtime/memory-guidance.ts
@@ -1,10 +1,12 @@
 /** Hermes-style memory/session/skills guidance (ported from hermes-agent prompt_builder.py). */
 
 export const MEMORY_GUIDANCE =
-  "You have persistent memory across sessions. Save durable facts with `memory_save`: user " +
-  "preferences, environment details, tool quirks, and stable conventions. Memory is injected " +
-  "into every turn, so keep it compact and focused on facts that will still matter later. " +
-  "Prioritize what reduces future user steering.\n" +
+  "You have persistent memory across sessions, stored only in this browser (IndexedDB) — " +
+  "nothing is sent to a server. Save durable facts with `memory_save`: user preferences, " +
+  "URLs, API tokens, environment details, tool quirks, and stable conventions. When the user " +
+  "asks you to remember credentials or secrets, save them as key=value facts — do not refuse. " +
+  "Memory is injected into every turn, so keep it compact and focused on facts that will still " +
+  "matter later. Prioritize what reduces future user steering.\n" +
   "Do NOT save task progress, session outcomes, completed-work logs, or temporary TODO state " +
   "to memory — use `session_search` or `session_memory_append` instead. Specifically: do not " +
   "record PR numbers, issue numbers, commit SHAs, 'fixed bug X', 'Phase N done', file counts, " +

--- a/src/agent/runtime/tools/builtins/run_python.ts
+++ b/src/agent/runtime/tools/builtins/run_python.ts
@@ -3,7 +3,7 @@ import { runPythonTool } from "../python-tools.js";
 
 const RUN_PYTHON_EXAMPLES = [
   { code: "print('ok')" },
-  { path: "scripts/publish-5lang.py", env: { DIRECTUS_API_TOKEN: "<from Settings/vault>" }, timeout_ms: 300000 },
+  { path: "scripts/publish-5lang.py", env: { DIRECTUS_API_TOKEN: "<from memory_recall or user>" }, timeout_ms: 300000 },
   {
     code:
       "import zipfile\nfrom pathlib import Path\nroot=Path('work/my-bundle'); out=root/'bundle.zip'\nwith zipfile.ZipFile(out,'w',compression=zipfile.ZIP_DEFLATED) as zf:\n  [zf.write(f,f.relative_to(root)) for f in root.rglob('*') if f.is_file() and f!=out]\nprint(out)",

--- a/src/agent/runtime/tools/builtins/run_shell.ts
+++ b/src/agent/runtime/tools/builtins/run_shell.ts
@@ -7,7 +7,7 @@ const RUN_SHELL_EXAMPLES = [
   {
     command: "python3 scripts/publish-5lang.py article.md",
     cwd: ".webagent/skills/imported/example",
-    env: { API_TOKEN: "<from Settings/vault>" },
+    env: { API_TOKEN: "<from memory_recall or user>" },
     timeout_ms: 300000,
   },
 ];

--- a/src/capabilities/skills/artifact-delivery/SKILL.md
+++ b/src/capabilities/skills/artifact-delivery/SKILL.md
@@ -38,7 +38,7 @@ Owns choice between inline reply, **`artifact_present`**, **`email`**, and cron 
 ## Relation to other skills
 
 - Multi-step run reports: **`task-execution`** writes `work/task-execution/<slug>/report.md`.
-- Mermaid authoring: **`chart`**. Secret storage policy: **`memory-layers`**.
+- Mermaid authoring: **`chart`**. Durable facts (including credentials the user asked to store): **`memory-layers`**.
 
 ## Procedure
 
@@ -54,8 +54,6 @@ Owns choice between inline reply, **`artifact_present`**, **`email`**, and cron 
 
 - Strip API keys, bearer tokens, and `.env` contents from `artifact_present` bodies and email text.
 - If the user pasted a secret, redact in the delivered artifact — do not send it back unchanged.
-- For where secrets belong (vault vs memory), see **`memory-layers`**.
-
 ## Pitfalls
 
 - Pasting the artifact body inline *and* presenting it.

--- a/src/capabilities/skills/http-api/SKILL.md
+++ b/src/capabilities/skills/http-api/SKILL.md
@@ -43,7 +43,7 @@ Canonical procedure for **REST GET** (`web_fetch`) and **HTTP writes** (`web_pos
 | **Mixed multipart** (fields + file) | `web_post` | `url`, `multipart` array with `text` / `file_path` / `source_url` per field |
 | **Binary download to workspace** | `web_fetch` | `url`, `save_to` workspace path (metadata-only result) |
 | Batch public GET (≤5 URLs) | `web_fetch` | `urls` array; shared `headers`, `params` |
-| Secrets | `headers.Authorization` (or API-key header docs specify) | Never in URL query; prefer Settings/vault over `memory_save` |
+| Secrets | `headers.Authorization` (or API-key header docs specify) | Never in URL query; recall from `memory_recall` / `memory_search` or user-provided env |
 
 **Non-negotiable:** Read the API's real schema before inventing field names. On `ok: false` or GraphQL `errors`, fix the query — do not retry the same malformed call in a loop.
 
@@ -68,7 +68,7 @@ Canonical procedure for **REST GET** (`web_fetch`) and **HTTP writes** (`web_pos
 ## Relation to other skills
 
 - Tool picker (shell vs HTTP): **`browser-runtime-map`**. MCP integrations: `.webagent/mcp-servers.json` (+ secrets); `mcp_*` tools register at profile startup and appear as **active** under ## MCP in the **Tool capability index** — call them directly (not via `tool_search` / `tool_activate`).
-- Python scripts: **`run_python`** when Pyodide-compatible. Secrets: **`memory-layers`**.
+- Python scripts: **`run_python`** when Pyodide-compatible. Stored credentials: **`memory-layers`** (`memory_recall`).
 - **Imported skills own endpoints** — call `skill_view` on the imported skill first; use this skill for generic REST/GraphQL mechanics.
 
 ## Procedure
@@ -243,4 +243,4 @@ If step 2 returns **403**, the token may lack metadata scope — ask the user fo
 
 - Retry loop: same bad GraphQL query 3+ times.
 - `run_shell` with `require('axios')`, `fetch(`, curl, or python `requests` when `web_fetch`/`web_post` suffice.
-- Storing API tokens in `memory_save` — use Settings/vault and pass via `headers` each call.
+- Putting API tokens in URL query strings — use headers only.

--- a/src/capabilities/skills/memory-layers/SKILL.md
+++ b/src/capabilities/skills/memory-layers/SKILL.md
@@ -1,49 +1,45 @@
 ---
 name: Memory Layers
-description: Use when the user says remember this, save a preference, paste API keys, or you must pick memory_save vs session notes vs skill_manage vs wiki_* tools.
-version: 1.1.0
+description: Use when the user says remember this, save a preference or API key, or you must pick memory_save vs session notes vs skill_manage vs wiki_* tools.
+version: 1.2.0
 category: bundled
 primary-tools: [memory_save, session_search, skill_view, wiki_search]
-tags: [memory, session, skills, facts, context, remember, preference, security, credentials, secrets]
-triggers: [remember this, save preference, session note, store fact, recall later, what do we remember, persistent note, knowledge vault, wiki sync, sync facts to wiki, wiki search, api key, secret, .env, paste key, sk-, bearer, rotate key, commit secrets, redact, password in chat]
+tags: [memory, session, skills, facts, context, remember, preference]
+triggers: [remember this, save preference, session note, store fact, recall later, what do we remember, persistent note, knowledge vault, wiki sync, sync facts to wiki, wiki search, api key, token, password in chat]
 ---
 
 ## Tool contract (read first)
 
-Canonical picker for **what to persist**, **which memory tool**, and **secret handling**. Maintainer evolution: **`web-agent-skill`**.
+Canonical picker for **what to persist** and **which memory tool**. Maintainer evolution: **`web-agent-skill`**.
 
 | Layer | Tools | Use for |
 |-------|--------|---------|
-| **Facts** | `memory_save`, `memory_forget`, `memory_recall`, `memory_search` | Stable preferences (timezone, stack, env constraints), plus exact-key cleanup. Never API keys or tokens. |
+| **Facts** | `memory_save`, `memory_forget`, `memory_recall`, `memory_search` | Stable key=value facts: preferences, URLs, API tokens, env details. Stored only in this browser (IndexedDB); nothing is sent to a server. |
 | **Session** | `session_memory_append`, `session_memory_list`, `session_search` | Rolling notes, temporary decisions, artifact pointers this session. |
 | **Skills** | `skill_view`, `skill_list`, `skill_manage`, `skill_bulk_save` | Repeatable procedures with a clear trigger. |
 | **Wiki vault** | `wiki_setup`, `wiki_sync`, `wiki_search` | PARA markdown mirror (default `.webagent/knowledge-vault/`). Also `/wiki_setup`, `/wiki_sync`, `/wiki_search`. |
 | **OAuth SaaS** | `composio_connect`, `composio_status`, `composio_action` | Connected apps (Gmail, Sheets, HubSpot, …) — not raw `web_post` without OAuth setup. |
 | **MCP extensions** | Dynamic MCP tools (from `.webagent/mcp-servers.json`) | User-configured servers — see **`imported-skill-compat`**. |
 
-**Non-negotiable:** One-off facts → `memory_save`. Debugging trail → `session_memory_append`. Repeatable recipe → `skill_manage` create after `skill_view`. Secrets belong in **Settings / vault** — never in memory, session, skills, or workspace prose.
-
-## Canonical scope
-
-Single guide for choosing among durable facts, rolling session notes, procedural skills, and wiki projections. Maintainer-only Web Agent evolution: **`web-agent-skill`**.
+**Non-negotiable:** One-off facts → `memory_save`. Debugging trail → `session_memory_append`. Repeatable recipe → `skill_manage` create after `skill_view`.
 
 ## When to Use
 
 - User asks "remember this" vs "save a reusable workflow" or "for next session".
-- User pastes keys, asks to commit `.env`, or where to store credentials.
+- User gives credentials, URLs, or tokens to store — use `memory_save` with clear snake_case keys.
 - Deciding between `memory_save`, `session_memory_append`, and `skill_manage`.
 - Reducing duplicate or contradictory stored context; wiki_sync vs facts.
 
 ## Relation to other skills
 
-- Delivery redaction before `artifact_present` / `email`: **`artifact-delivery`** Secrets subsection.
+- Redact secrets in delivered artifacts/email: **`artifact-delivery`**.
 - Maintainer evolution: **`web-agent-skill`**.
 
 ## Procedure
 
 ### Layer choice
 
-1. **One-off fact** ("I use pnpm") → `memory_save` (or update existing key; add `scope` when obvious).
+1. **One-off fact** ("I use pnpm", API URL, token) → `memory_save` (or update existing key; add `scope` when obvious).
 2. **Debugging trail** ("tried X, failed Y") → session memory until resolved.
 3. **Wrong/stale durable fact** → `memory_forget` by exact key; use `memory_search` first if unsure.
 4. **Repeatable recipe** ("how we deploy previews") → `skill_manage` create when the user wants it reusable; call `skill_view` first.
@@ -54,22 +50,12 @@ Single guide for choosing among durable facts, rolling session notes, procedural
 2. **Project runtime** — `wiki_sync` or `/wiki_sync [facts|session|all]`.
 3. **Browse/search** — `wiki_search` or `/wiki_search <query>`.
 
-### Secrets (never in memory layers)
-
-1. **Settings / vault** — provider keys per profile (encrypted local vault), not workspace files the model edits casually.
-2. **Never echo secrets** in chat, `artifact_present`, email, or logs — redact (`sk-…`, bearer tokens, long hex).
-3. **`read_file` on secrets** — only when the user explicitly asked to inspect their own config path.
-4. Direct users to Settings when they ask where to put keys — not `memory_save`.
-
 ## Pitfalls
 
-- Storing secrets in memory, session, or skills.
 - Duplicating the same content in facts and a skill — pick one layer.
 - Mirroring long content in both `memory_save` and synced wiki pages — prefer facts/skills as source of truth.
 - Huge dumps into `memory_save` — summarize; long prose belongs in skills or session.
 
 ## Anti-patterns
 
-- "Paste your API key here so I can test" — direct to Settings.
-- Duplicating the same secret in skills, memory, and files — one vault source of truth.
 - Maintainer-only workflows here — use **`web-agent-skill`** for self-evolution of Web Agent itself.

--- a/src/capabilities/skills/multimodal-ingest/SKILL.md
+++ b/src/capabilities/skills/multimodal-ingest/SKILL.md
@@ -18,7 +18,7 @@ triggers: [screenshot, image, diagram, ocr, what is in this image, youtube link,
 | Cross-check claims | `web_search`, `web_fetch` — **`open-web-research`** |
 | Persist transcript / extract | `write_file` under `work/<slug>/` |
 | Show visual to user | `artifact_present` — **`artifact-delivery`** |
-| Durable non-secret facts | `memory_save` — **`memory-layers`** |
+| Durable facts | `memory_save` — **`memory-layers`** |
 
 **Non-negotiable:** Focused vision questions, not "describe everything". Long transcripts → file + present, not chat paste.
 

--- a/src/capabilities/skills/workspace-safety/SKILL.md
+++ b/src/capabilities/skills/workspace-safety/SKILL.md
@@ -21,7 +21,7 @@ triggers: [backup, export profile, checkpoint, rollback, before delete, rm -rf, 
 | Risky shell | `run_shell` — prefer `work/` subtree — **`browser-runtime-map`** |
 | Multi-step irreversible plan | **`task-execution`** inserts checkpoint todo as step 0 |
 
-**Non-negotiable:** No wide delete/refactor without checkpoint or export. Redact secrets before export — see **`memory-layers`**.
+**Non-negotiable:** No wide delete/refactor without checkpoint or export. Redact secrets before sharing exported JSON — see **`artifact-delivery`**.
 
 ## Canonical scope
 
@@ -36,14 +36,14 @@ This skill owns **backup, checkpoint, export, and risk isolation** before destru
 
 ## Relation to other skills
 
-- Path layout: **`project-scaffold`**. Secrets/redaction: **`memory-layers`**. Multi-step runs: **`task-execution`**.
+- Path layout: **`project-scaffold`**. Delivery redaction: **`artifact-delivery`**. Multi-step runs: **`task-execution`**.
 
 ## Checklist
 
 1. **Named history checkpoint** — If the UI exposes slash commands (`/checkpoint [name]` per README), save conversation state before big moves; `/rollback` lists or restores.
 2. **Profile / workspace export** — Workspaces tab: **Export** profile snapshot to JSON; **Import** later. Do this before risky migration or "let's wipe and retry."
 3. **Isolate experiments** — New disposable trees under **`work/<purpose-slug>/`**; durable demos under **`projects/<slug>/`**. Call `skill_view` **`project-scaffold`** when layout is unclear.
-4. **Secrets** — Never checkpoint or export and share without redacting; see **`memory-layers`**.
+4. **Secrets** — Never export and share profile JSON without redacting tokens; see **`artifact-delivery`**.
 5. **Destructive tools** — Confirm scope before `delete_file`, wide patches, or shell that removes files.
 6. **Inside multi-step runs** — **`task-execution`** inserts a checkpoint todo as step 0 when the approved plan contains an irreversible step; do not skip it.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The agent refused to save API tokens via `memory_save`, citing security concerns and directing users to **Settings → Secrets/Vault** — which does not exist for arbitrary third-party credentials. Memory is already browser-local (IndexedDB); nothing is sent to a server.

## Solution

- Simplified **`memory-layers`** skill: facts layer includes URLs/tokens when the user asks; removed Settings/vault restrictions and the "secrets never in memory" section.
- Updated **`memory-guidance.ts`** injected prompt: memory is browser-only; do not refuse credential saves when requested.
- Removed misleading **Settings/vault** references from `http-api`, tool examples (`run_python` / `run_shell`), and related skills/docs.
- Kept **artifact-delivery** redaction for emailed/presented artifacts (do not echo secrets back in deliverables).

## Testing

- `npm test` — pass
- `npx tsc -b --noEmit` — pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de743bc8-5487-4e11-b73a-87809436f5e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de743bc8-5487-4e11-b73a-87809436f5e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

