### PR TITLE
Fix HTML spill snapshots and richer list_digest for API lists

### DIFF
--- a/src/agent/runtime/memory-guidance.ts
+++ b/src/agent/runtime/memory-guidance.ts
@@ -72,7 +72,7 @@ export const COMPOSIO_SAAS_GUIDANCE =
 export const MEMORY_SPILL_RECOVERY_GUIDANCE =
   "**Internal memory paths (do not scavenge):** `memory/snapshots/` = oversized tool-result spill only; " +
   "`memory/runs/` = agent turn logs (tool names/errors), not API payloads. Never `list_dir`, `find_files`, or `grep` under those trees to recover HTTP data. " +
-  "When compact tool output shows `result_ref`, `read_file` that exact path once (content is auto-unwrapped). If missing/stale/nested, rerun `web_fetch`/`web_post`/`grep` on real project paths — not `run_shell head` on memory files. " +
+  "When compact tool output shows `list_digest`, use it — do not read_file the spill. When only `result_ref` is present, read_file that path once (auto-unwrapped). If the body is HTML or invalid JSON, rerun `web_fetch`/`web_post` with Authorization — never JSON.parse spill files. " +
   "For prior chat context use `session_search`, not raw run JSON.";
 
 export function buildMemoryLayerGuidanceBlock(toolNames: string[] = []): string {

--- a/src/agent/runtime/memory/snapshots.ts
+++ b/src/agent/runtime/memory/snapshots.ts
@@ -12,7 +12,12 @@ import {
   memoryPath,
   safeWriteJson,
 } from "./sql.js";
-import { extractToolResultBodyText, looksLikeBinaryPayload } from "../tool-result-preview.js";
+import {
+  extractToolResultBodyText,
+  htmlApiBodyRecoveryNote,
+  looksLikeBinaryPayload,
+  looksLikeHtmlDocument,
+} from "../tool-result-preview.js";
 import { isMemorySnapshotSpillPath } from "./internal-paths.js";
 
 /** Same prefix as agent/context-compaction tool-result injection (must match exactly). */
@@ -220,10 +225,22 @@ export function unwrapMemorySnapshotReadContent(
   try {
     parsed = JSON.parse(rawContent);
   } catch {
+    if (looksLikeHtmlDocument(rawContent)) {
+      return {
+        content: htmlApiBodyRecoveryNote(rawContent),
+        from_snapshot: true,
+        html_shell: true,
+      };
+    }
     return null;
   }
   const execPayload = parsed?.payload;
   if (!execPayload || typeof execPayload !== "object") return null;
+
+  const spillUrl =
+    execPayload.result && typeof execPayload.result === "object"
+      ? String((execPayload.result as Record<string, unknown>).url || "")
+      : "";
 
   let text = extractPayloadResultText(execPayload);
   if (text == null && execPayload.result && typeof execPayload.result === "object") {
@@ -234,6 +251,14 @@ export function unwrapMemorySnapshotReadContent(
     }
   }
   if (text == null) return null;
+
+  if (looksLikeHtmlDocument(text)) {
+    return {
+      content: htmlApiBodyRecoveryNote(text, spillUrl),
+      from_snapshot: true,
+      html_shell: true,
+    };
+  }
 
   const trimmed = text.trimStart();
   if (trimmed.startsWith("{") && trimmed.includes('"payload"')) {

--- a/src/agent/runtime/memory/snapshots.ts
+++ b/src/agent/runtime/memory/snapshots.ts
@@ -216,7 +216,13 @@ export function unwrapMemorySnapshotReadContent(
   relPath: string,
   rawContent: string,
   depth = 0
-): { content: string; from_snapshot: true; content_truncated?: boolean; unwrap_depth?: number } | null {
+): {
+  content: string;
+  from_snapshot: true;
+  content_truncated?: boolean;
+  unwrap_depth?: number;
+  html_shell?: boolean;
+} | null {
   if (depth > 5) return null;
   const p = String(relPath || "");
   if (!isMemorySnapshotSpillPath(p) && !/snapshots\/run_/.test(p)) return null;
@@ -237,13 +243,26 @@ export function unwrapMemorySnapshotReadContent(
   const execPayload = parsed?.payload;
   if (!execPayload || typeof execPayload !== "object") return null;
 
-  const spillUrl =
+  const resultObj =
     execPayload.result && typeof execPayload.result === "object"
-      ? String((execPayload.result as Record<string, unknown>).url || "")
-      : "";
+      ? (execPayload.result as Record<string, unknown>)
+      : null;
+  const spillUrl = resultObj ? String(resultObj.url || "") : "";
+  if (resultObj) {
+    const rawBody = [resultObj.text, resultObj.content, resultObj.data].find(
+      (v) => typeof v === "string" && v.trim()
+    ) as string | undefined;
+    if (rawBody && looksLikeHtmlDocument(rawBody)) {
+      return {
+        content: htmlApiBodyRecoveryNote(rawBody, spillUrl),
+        from_snapshot: true,
+        html_shell: true,
+      };
+    }
+  }
 
   let text = extractPayloadResultText(execPayload);
-  if (text == null && execPayload.result && typeof execPayload.result === "object") {
+  if (text == null && resultObj) {
     try {
       text = JSON.stringify(execPayload.result, null, 2);
     } catch {
@@ -251,14 +270,6 @@ export function unwrapMemorySnapshotReadContent(
     }
   }
   if (text == null) return null;
-
-  if (looksLikeHtmlDocument(text)) {
-    return {
-      content: htmlApiBodyRecoveryNote(text, spillUrl),
-      from_snapshot: true,
-      html_shell: true,
-    };
-  }
 
   const trimmed = text.trimStart();
   if (trimmed.startsWith("{") && trimmed.includes('"payload"')) {

--- a/src/agent/runtime/stream-output.ts
+++ b/src/agent/runtime/stream-output.ts
@@ -3,7 +3,12 @@
  */
 
 import { setTimeout as sleep } from "node:timers/promises";
-import { summarizeToolResultPreview, extractHttpListDigest } from "./tool-result-preview.js";
+import {
+  extractHttpListDigest,
+  htmlApiBodyRecoveryNote,
+  httpResultLooksLikeHtmlShell,
+  summarizeToolResultPreview,
+} from "./tool-result-preview.js";
 
 export function summarizeToolExecutions(exec, snapshotRefs = []) {
   return exec.map((item, index) => {
@@ -17,7 +22,23 @@ export function summarizeToolExecutions(exec, snapshotRefs = []) {
     } else if (resultRef) {
       const preview = summarizeToolResultPreview(item?.result);
       const digest = extractHttpListDigest(item?.result);
-      if (digest) {
+      const htmlShell = httpResultLooksLikeHtmlShell(item?.result);
+      if (htmlShell) {
+        const url =
+          item?.result && typeof item.result === "object"
+            ? String((item.result as Record<string, unknown>).url || "")
+            : "";
+        const body =
+          item?.result && typeof item.result === "object"
+            ? (item.result as Record<string, unknown>).text ||
+              (item.result as Record<string, unknown>).content ||
+              (item.result as Record<string, unknown>).data
+            : "";
+        summary =
+          `payload_spilled but response is HTML, not JSON (${resultRef}). ` +
+          `${htmlApiBodyRecoveryNote(body, url).replace(/\s+/g, " ").trim().slice(0, 280)} ` +
+          "Do not read_file or JSON.parse the spill — rerun web_fetch/web_post with Authorization.";
+      } else if (digest) {
         const sample = (digest.preview ?? digest.slugs).slice(0, 12);
         summary =
           `payload_spilled_to_snapshot (${resultRef}). Use list_digest below — do not read_file unless you need fields beyond this list. ` +

--- a/src/agent/runtime/stream-output.ts
+++ b/src/agent/runtime/stream-output.ts
@@ -17,12 +17,15 @@ export function summarizeToolExecutions(exec, snapshotRefs = []) {
     } else if (resultRef) {
       const preview = summarizeToolResultPreview(item?.result);
       const digest = extractHttpListDigest(item?.result);
-      summary =
-        `payload_spilled_to_snapshot: full tool result is in "${resultRef}" — read_file that path once (auto-unwrapped). ` +
-        `Preview: ${preview}. Do not list/grep memory/snapshots or memory/runs; if stale or nested, rerun the originating tool (web_fetch, web_post, grep, etc.).`;
       if (digest) {
-        const sample = digest.slugs.slice(0, 48);
-        summary += ` List digest (${digest.total}): ${sample.join(", ")}${digest.total > sample.length ? ", …" : ""}.`;
+        const sample = (digest.preview ?? digest.slugs).slice(0, 12);
+        summary =
+          `payload_spilled_to_snapshot (${resultRef}). Use list_digest below — do not read_file unless you need fields beyond this list. ` +
+          `List digest (${digest.total}): ${sample.join(" | ")}${digest.total > sample.length ? " | …" : ""}.`;
+      } else {
+        summary =
+          `payload_spilled_to_snapshot: full tool result is in "${resultRef}" — read_file that path once (auto-unwrapped). ` +
+          `Preview: ${preview}. Do not list/grep memory/snapshots or memory/runs; if stale or nested, rerun the originating tool (web_fetch, web_post, grep, etc.).`;
       }
       const tr = item?.result;
       if (tr && typeof tr === "object" && tr.truncated === true) {

--- a/src/agent/runtime/tool-result-preview.ts
+++ b/src/agent/runtime/tool-result-preview.ts
@@ -1,3 +1,11 @@
+import { spaShellPageRecoveryHint } from "./tools/tinyfish-fetch.js";
+
+/** True when body looks like an HTML document (SPA shell, login page, CDN error). */
+export function looksLikeHtmlDocument(text: unknown): boolean {
+  const t = String(text || "").trimStart().slice(0, 256).toLowerCase();
+  return t.startsWith("<!doctype") || t.startsWith("<html") || /^<\?xml[\s>]/.test(t);
+}
+
 /**
  * One-line summary of tool `result` for compact "Tool results (compact JSON)" messages.
  * Must surface real body fields (`content`, `text`, `markdown`, `transcript`, directory listings) —
@@ -155,8 +163,25 @@ function slugFromListRow(row: unknown): string | null {
   return null;
 }
 
-/** Slim slug/id list from large JSON list/metadata API responses (for spilled compact rows). */
-export function extractHttpListDigest(result: unknown): { slugs: string[]; total: number } | null {
+function formatHttpItemDigestLine(row: unknown): string | null {
+  if (typeof row === "string" && row.trim()) return row.trim();
+  if (!row || typeof row !== "object") return null;
+  const obj = row as Record<string, unknown>;
+  const title = [obj.title, obj.name, obj.headline, obj.slug]
+    .find((v) => typeof v === "string" && v.trim());
+  const date = [obj.date_created, obj.date_updated, obj.published_at, obj.created_at, obj.updated_at]
+    .find((v) => typeof v === "string" && v.trim());
+  if (typeof title === "string" && title.trim()) {
+    const d = typeof date === "string" ? date.trim().slice(0, 10) : "";
+    return d ? `${title.trim()} (${d})` : title.trim();
+  }
+  return slugFromListRow(row);
+}
+
+/** Slim list from large JSON list/metadata API responses (for spilled compact rows). */
+export function extractHttpListDigest(
+  result: unknown
+): { slugs: string[]; total: number; preview?: string[] } | null {
   if (!result || typeof result !== "object") return null;
   const obj = result as Record<string, unknown>;
   const url = typeof obj.url === "string" ? obj.url : "";
@@ -175,15 +200,35 @@ export function extractHttpListDigest(result: unknown): { slugs: string[]; total
   if (!items?.length) return null;
 
   const slugs: string[] = [];
+  const preview: string[] = [];
   const seen = new Set<string>();
   for (const row of items) {
+    const line = formatHttpItemDigestLine(row);
     const slug = slugFromListRow(row);
-    if (!slug || seen.has(slug)) continue;
-    seen.add(slug);
-    slugs.push(slug);
+    if (line && !seen.has(line)) {
+      seen.add(line);
+      preview.push(line);
+      if (slug && !slugs.includes(slug)) slugs.push(slug);
+    } else if (slug && !seen.has(slug)) {
+      seen.add(slug);
+      slugs.push(slug);
+      preview.push(slug);
+    }
   }
-  if (!slugs.length) return null;
-  return { slugs, total: slugs.length };
+  if (!preview.length && !slugs.length) return null;
+  return {
+    slugs: preview.length ? preview : slugs,
+    total: items.length,
+    preview: preview.length ? preview : undefined,
+  };
+}
+
+/** Human-readable note when an HTTP tool body is HTML instead of JSON. */
+export function htmlApiBodyRecoveryNote(text: unknown, url?: string): string {
+  const hint =
+    spaShellPageRecoveryHint(text, url) ||
+    "Response body is HTML, not JSON — add Authorization (Bearer) on web_fetch/web_post and rerun; do not read_file snapshot spill files that contain HTML.";
+  return `[API returned HTML, not JSON] ${hint}`;
 }
 
 export function summarizeToolResultPreview(value: unknown) {

--- a/src/agent/runtime/tool-result-preview.ts
+++ b/src/agent/runtime/tool-result-preview.ts
@@ -2,8 +2,27 @@ import { spaShellPageRecoveryHint } from "./tools/tinyfish-fetch.js";
 
 /** True when body looks like an HTML document (SPA shell, login page, CDN error). */
 export function looksLikeHtmlDocument(text: unknown): boolean {
-  const t = String(text || "").trimStart().slice(0, 256).toLowerCase();
-  return t.startsWith("<!doctype") || t.startsWith("<html") || /^<\?xml[\s>]/.test(t);
+  const t = String(text || "").trimStart().slice(0, 512).toLowerCase();
+  if (!t.startsWith("<")) return false;
+  return (
+    t.startsWith("<!doctype") ||
+    t.startsWith("<html") ||
+    t.startsWith("<head") ||
+    t.startsWith("<body") ||
+    /^<\?xml[\s>]/.test(t)
+  );
+}
+
+/** True when a web_fetch/web_post result body is HTML instead of API JSON. */
+export function httpResultLooksLikeHtmlShell(result: unknown): boolean {
+  if (!result || typeof result !== "object") return false;
+  const obj = result as Record<string, unknown>;
+  for (const key of ["text", "content", "markdown"]) {
+    const v = obj[key];
+    if (typeof v === "string" && looksLikeHtmlDocument(v)) return true;
+  }
+  if (typeof obj.data === "string" && looksLikeHtmlDocument(obj.data)) return true;
+  return false;
 }
 
 /**
@@ -118,13 +137,24 @@ export function extractToolResultBodyText(inner: unknown): string | null {
   if (!inner || typeof inner !== "object") return null;
   const obj = inner as Record<string, unknown>;
 
-  if (typeof obj.text === "string" && obj.text.trim()) return obj.text;
+  if (typeof obj.text === "string" && obj.text.trim()) {
+    if (looksLikeHtmlDocument(obj.text)) {
+      return htmlApiBodyRecoveryNote(obj.text, typeof obj.url === "string" ? obj.url : undefined);
+    }
+    return obj.text;
+  }
   if (typeof obj.markdown === "string" && obj.markdown.trim()) return obj.markdown;
   if (typeof obj.transcript === "string" && obj.transcript.trim()) return obj.transcript;
   if (typeof obj.error === "string" && obj.error.trim()) return obj.error;
 
   if (obj.data !== undefined && obj.data !== null) {
-    if (typeof obj.data === "string" && obj.data.trim()) return obj.data;
+    if (typeof obj.data === "string" && obj.data.trim()) {
+      const d = obj.data.trim();
+      if (looksLikeHtmlDocument(d)) {
+        return htmlApiBodyRecoveryNote(d, typeof obj.url === "string" ? obj.url : undefined);
+      }
+      return d;
+    }
     try {
       return JSON.stringify(obj.data, null, 2);
     } catch {
@@ -190,6 +220,22 @@ export function extractHttpListDigest(
   let items: unknown[] | null = null;
   if (Array.isArray(obj.data)) {
     items = obj.data;
+  } else if (typeof obj.data === "string" && obj.data.trim()) {
+    const raw = obj.data.trim();
+    if (looksLikeHtmlDocument(raw)) return null;
+    if (raw.startsWith("[") || raw.startsWith("{")) {
+      try {
+        const parsed = JSON.parse(raw) as unknown;
+        if (Array.isArray(parsed)) items = parsed;
+        else if (parsed && typeof parsed === "object") {
+          const nested = parsed as Record<string, unknown>;
+          if (Array.isArray(nested.data)) items = nested.data;
+          else if (Array.isArray(nested.items)) items = nested.items;
+        }
+      } catch {
+        return null;
+      }
+    }
   } else if (obj.data && typeof obj.data === "object") {
     const nested = obj.data as Record<string, unknown>;
     if (Array.isArray(nested.data)) items = nested.data;
@@ -248,6 +294,13 @@ export function summarizeToolResultPreview(value: unknown) {
     for (const key of ["content", "text", "markdown", "transcript", "error"]) {
       const raw = obj[key];
       if (typeof raw === "string" && raw.trim()) {
+        if (looksLikeHtmlDocument(raw)) {
+          const note = htmlApiBodyRecoveryNote(
+            raw,
+            typeof obj.url === "string" ? obj.url : undefined
+          );
+          return `html_shell: ${note.replace(/\s+/g, " ").trim().slice(0, 320)}`;
+        }
         const compact = raw.replace(/\s+/g, " ").trim();
         const cap = obj.from_snapshot ? 2_500 : 600;
         const excerpt = compact.length > cap ? `${compact.slice(0, cap)}…` : compact;
@@ -255,6 +308,13 @@ export function summarizeToolResultPreview(value: unknown) {
       }
     }
     if (obj.data !== undefined && obj.data !== null) {
+      if (typeof obj.data === "string" && looksLikeHtmlDocument(obj.data)) {
+        const note = htmlApiBodyRecoveryNote(
+          obj.data,
+          typeof obj.url === "string" ? obj.url : undefined
+        );
+        return `html_shell: ${note.replace(/\s+/g, " ").trim().slice(0, 320)}`;
+      }
       const serialized =
         typeof obj.data === "string" ? obj.data : JSON.stringify(obj.data);
       const compact = serialized.replace(/\s+/g, " ").trim();

--- a/src/agent/runtime/tools/builtins/read_file.ts
+++ b/src/agent/runtime/tools/builtins/read_file.ts
@@ -7,8 +7,9 @@ export default defineTool({
   emoji: "📄",
   description:
     "Read a UTF-8 file. **`path`** is workspace-relative (`.` = root). " +
-    "Do not read `memory/runs/*.json` (agent logs) or browse `memory/snapshots/` except the exact `result_ref` from tool output (auto-unwrapped). " +
-    "For API data, rerun `web_fetch`/`web_post` instead of scavenging memory archives. " +
+    "Do not read `memory/runs/*.json` (agent logs) or browse `memory/snapshots/`. " +
+    "When tool output has `list_digest`, use it — do not read_file the spill. " +
+    "Otherwise read the exact `result_ref` once (auto-unwrapped). HTML spills need Authorization on a fresh web_fetch, not JSON.parse. " +
     "Run `list_dir({\"path\":\".\"})`, `tree`, or `find_files` before guessing paths. Returns { ok, path, bytes, content }.",
   inputSchema: {
     type: "object",

--- a/src/agent/runtime/tools/filesystem/read.ts
+++ b/src/agent/runtime/tools/filesystem/read.ts
@@ -14,6 +14,10 @@ import {
   unwrapMemorySnapshotReadContent,
 } from "../../memory/snapshots.js";
 import {
+  htmlApiBodyRecoveryNote,
+  looksLikeHtmlDocument,
+} from "../../tool-result-preview.js";
+import {
   isMemoryRunArchivePath,
   isMemorySnapshotSpillPath,
   memoryRunArchiveBlockedMessage,
@@ -41,7 +45,30 @@ export function getReadFileMaxChars() {
   return SNAPSHOT_READ_UNWRAP_MAX_CHARS;
 }
 
+function snapshotReadFailure(rel: string, content: string): Error | null {
+  if (!isMemorySnapshotSpillPath(rel)) return null;
+  const trimmed = content.trimStart();
+  if (looksLikeHtmlDocument(trimmed)) {
+    return new Error(
+      `${htmlApiBodyRecoveryNote(trimmed)} Do not JSON.parse this spill — rerun web_fetch/web_post with Authorization headers.`
+    );
+  }
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+    try {
+      JSON.parse(content);
+    } catch (e) {
+      return new Error(
+        `Snapshot spill is not valid JSON (${errorMessage(e)}). Rerun web_fetch with limit/sort/fields — do not read_file this path again.`
+      );
+    }
+  }
+  return null;
+}
+
 function formatReadFileSuccess(rel: string, content: string) {
+  const spillErr = snapshotReadFailure(rel, content);
+  if (spillErr) throw spillErr;
+
   const unwrapped = isMemorySnapshotSpillPath(rel)
     ? unwrapMemorySnapshotReadContent(rel, content)
     : null;

--- a/src/agent/runtime/tools/remote-tools.ts
+++ b/src/agent/runtime/tools/remote-tools.ts
@@ -16,6 +16,7 @@ import { logDebugEvent } from "../logging/debug-log.js";
 import * as memoryModule from "../memory/index.js";
 import { memoryPath } from "../memory/sql.js";
 import { createTimeoutController } from "./context.js";
+import { looksLikeHtmlDocument } from "../tool-result-preview.js";
 import { parseTinyFishFetchPayload, spaShellPageRecoveryHint } from "./tinyfish-fetch.js";
 import { expandSkillBulkSaveArgs } from "./skill-bulk-args.js";
 import {
@@ -803,9 +804,12 @@ export async function httpProxyCall(
       ...(sliced.truncated ? { truncated: true, truncated_at_chars: sliced.truncated_at_chars } : {}),
     };
   }
+  const recovery_hint =
+    looksLikeHtmlDocument(sliced.text) ? spaShellPageRecoveryHint(sliced.text, url) : undefined;
   return {
     ...base,
     text: sliced.text,
+    ...(recovery_hint ? { recovery_hint } : {}),
     ...(sliced.truncated ? { truncated: true, truncated_at_chars: sliced.truncated_at_chars } : {}),
   };
 }

--- a/src/agent/runtime/tools/remote-tools.ts
+++ b/src/agent/runtime/tools/remote-tools.ts
@@ -750,6 +750,18 @@ export async function httpProxyCall(
       parsedJson = JSON.parse(sliced.text);
     } catch {
       parsedJson = undefined;
+      if (trimmed.startsWith("<")) {
+        const recovery_hint = spaShellPageRecoveryHint(sliced.text, url);
+        return {
+          ok: true as const,
+          status,
+          url,
+          contentType,
+          text: sliced.text,
+          ...(recovery_hint ? { recovery_hint } : {}),
+          ...(sliced.truncated ? { truncated: true, truncated_at_chars: sliced.truncated_at_chars } : {}),
+        };
+      }
     }
   }
   if (!ok) {

--- a/src/agent/runtime/turn-continuation.ts
+++ b/src/agent/runtime/turn-continuation.ts
@@ -752,9 +752,9 @@ export function buildContinuationNudge(
   }
   if (kind === "snapshot_read_stall") {
     return (
-      "You read a memory/snapshots spill file. Use the unwrapped `content` from that read_file result (or the inlined `result` " +
-      "in the latest \"Tool results (compact JSON)\" message) to answer the user. For JSON APIs, collections/metadata live in " +
-      "the unwrapped body — do not read another snapshot path or rerun web_fetch unless that payload is missing or stale."
+      "You read a memory/snapshots spill file. Prefer `list_digest` from the latest \"Tool results (compact JSON)\" when present. " +
+      "Otherwise use unwrapped `content` from read_file (or inlined `result`). If the body is HTML or an auth recovery note, " +
+      "rerun web_fetch/web_post with Authorization — do not read_file another snapshot or JSON.parse spill files."
     );
   }
   if (kind === "api_discovery_stall") {

--- a/src/capabilities/skills/http-api/SKILL.md
+++ b/src/capabilities/skills/http-api/SKILL.md
@@ -22,6 +22,8 @@ triggers: [graphql, REST API, bearer token, web_post, authenticated fetch, api c
 
 **Anti-pattern (causes 240s timeouts):** `web_fetch` binary → base64 in `web_post` body → `read_file` snapshot loop. Stop and use `web_upload.file_path` or `source_url` instead.
 
+**Spilled list APIs:** When compact tool output includes `list_digest`, answer from that — do not `read_file` `memory/snapshots/`. If the summary says the body is HTML, add `Authorization` and rerun `web_fetch` (do not parse the spill as JSON).
+
 ### Directus-style publish (3 steps)
 
 1. **Upload file** — `web_upload` to `/files` with `source_url` or `file_path` (Telegram inbox paths work as `file_path`).

--- a/tests/snapshot-read-unwrap.test.ts
+++ b/tests/snapshot-read-unwrap.test.ts
@@ -7,7 +7,6 @@ import {
   spillInlineCharBudgetForToolResultItem,
   decideToolResultCompression,
 } from "../dist/agent-runtime/memory/index.js";
-
 test("unwrapMemorySnapshotReadContent inlines nested web_fetch body", () => {
   const inner = { ok: true, text: "collections payload" };
   const raw = JSON.stringify({
@@ -16,6 +15,21 @@ test("unwrapMemorySnapshotReadContent inlines nested web_fetch body", () => {
   const out = unwrapMemorySnapshotReadContent("memory/snapshots/run_x_r1_0.json", raw);
   assert.equal(out?.from_snapshot, true);
   assert.match(out?.content ?? "", /collections payload/);
+});
+
+test("unwrapMemorySnapshotReadContent surfaces HTML API shell as recovery text", () => {
+  const html = "<!DOCTYPE html><html><body>Please enable JavaScript</body></html>";
+  const raw = JSON.stringify({
+    payload: {
+      tool: "web_fetch",
+      result: { ok: true, url: "https://hub.example.com/items/articles", text: html },
+    },
+  });
+  const out = unwrapMemorySnapshotReadContent("memory/snapshots/run_html_r1_0.json", raw);
+  assert.equal(out?.from_snapshot, true);
+  assert.equal(out?.html_shell, true);
+  assert.match(out?.content ?? "", /API returned HTML/i);
+  assert.match(out?.content ?? "", /Authorization/i);
 });
 
 test("unwrapMemorySnapshotReadContent inlines web_fetch JSON data field", () => {

--- a/tests/snapshot-spill-cascade.test.ts
+++ b/tests/snapshot-spill-cascade.test.ts
@@ -73,5 +73,7 @@ test("summarizeToolExecutions adds list_digest when metadata payload spills", ()
   const rows = summarizeToolExecutions(exec, ["memory/snapshots/run_x_r0_0.json"]);
   assert.match(rows[0].summary, /List digest \(2\)/);
   assert.match(rows[0].summary, /job_postings/);
+  assert.match(rows[0].summary, /list_digest below/i);
+  assert.match(rows[0].summary, /do not read_file/i);
   assert.deepEqual(rows[0].list_digest?.slugs, ["job_postings", "Leads"]);
 });

--- a/tests/tool-result-preview.test.ts
+++ b/tests/tool-result-preview.test.ts
@@ -3,9 +3,11 @@ import assert from "node:assert/strict";
 
 import {
   extractHttpListDigest,
+  httpResultLooksLikeHtmlShell,
   looksLikeHtmlDocument,
   summarizeToolResultPreview,
 } from "../dist/agent-runtime/tool-result-preview.js";
+import { summarizeToolExecutions } from "../dist/agent-runtime/stream-output.js";
 
 test("summarizeToolResultPreview includes text excerpt for web_fetch-shaped result", () => {
   const s = summarizeToolResultPreview({
@@ -33,7 +35,56 @@ test("extractHttpListDigest prefers article title and date for /items/ responses
 
 test("looksLikeHtmlDocument detects doctype pages", () => {
   assert.equal(looksLikeHtmlDocument("<!DOCTYPE html><html>"), true);
+  assert.equal(looksLikeHtmlDocument("<body>login</body>"), true);
   assert.equal(looksLikeHtmlDocument('{"data":[]}'), false);
+});
+
+test("httpResultLooksLikeHtmlShell detects web_fetch HTML text", () => {
+  assert.equal(
+    httpResultLooksLikeHtmlShell({
+      ok: true,
+      url: "https://hub.example.com/items/articles",
+      text: "<!DOCTYPE html><html></html>",
+    }),
+    true
+  );
+  assert.equal(
+    httpResultLooksLikeHtmlShell({
+      ok: true,
+      url: "https://hub.example.com/items/articles",
+      data: [{ title: "ok" }],
+    }),
+    false
+  );
+});
+
+test("summarizeToolExecutions warns on spilled HTML without list_digest", () => {
+  const rows = summarizeToolExecutions(
+    [
+      {
+        tool: "web_fetch",
+        result: {
+          ok: true,
+          url: "https://hub.example.com/items/articles",
+          text: "<!DOCTYPE html><html><body>Please enable JavaScript</body></html>",
+        },
+      },
+    ],
+    ["memory/snapshots/run_html_r0_0.json"]
+  );
+  assert.match(rows[0].summary, /HTML, not JSON/i);
+  assert.match(rows[0].summary, /do not read_file/i);
+  assert.equal(rows[0].list_digest, undefined);
+});
+
+test("summarizeToolResultPreview abbreviates HTML web_fetch bodies", () => {
+  const s = summarizeToolResultPreview({
+    ok: true,
+    url: "https://hub.example.com/items/articles",
+    text: "<!DOCTYPE html><html><body>x</body></html>",
+  });
+  assert.match(s, /^html_shell:/);
+  assert.doesNotMatch(s, /<!DOCTYPE/);
 });
 
 test("summarizeToolResultPreview includes JSON data excerpt for web_fetch", () => {

--- a/tests/tool-result-preview.test.ts
+++ b/tests/tool-result-preview.test.ts
@@ -1,7 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { summarizeToolResultPreview } from "../dist/agent-runtime/tool-result-preview.js";
+import {
+  extractHttpListDigest,
+  looksLikeHtmlDocument,
+  summarizeToolResultPreview,
+} from "../dist/agent-runtime/tool-result-preview.js";
 
 test("summarizeToolResultPreview includes text excerpt for web_fetch-shaped result", () => {
   const s = summarizeToolResultPreview({
@@ -12,6 +16,24 @@ test("summarizeToolResultPreview includes text excerpt for web_fetch-shaped resu
   assert.match(s, /^text \(\d+ chars\):/);
   assert.match(s, /hello world/);
   assert.match(s, /…$/);
+});
+
+test("extractHttpListDigest prefers article title and date for /items/ responses", () => {
+  const digest = extractHttpListDigest({
+    ok: true,
+    url: "https://hub.example.com/items/articles",
+    data: [
+      { id: "a1", title: "Latest launch", date_created: "2026-05-20T12:00:00" },
+      { id: "a2", title: "Weekly recap", date_created: "2026-05-18T09:00:00" },
+    ],
+  });
+  assert.equal(digest?.total, 2);
+  assert.deepEqual(digest?.preview, ["Latest launch (2026-05-20)", "Weekly recap (2026-05-18)"]);
+});
+
+test("looksLikeHtmlDocument detects doctype pages", () => {
+  assert.equal(looksLikeHtmlDocument("<!DOCTYPE html><html>"), true);
+  assert.equal(looksLikeHtmlDocument('{"data":[]}'), false);
 });
 
 test("summarizeToolResultPreview includes JSON data excerpt for web_fetch", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After a successful `web_fetch` that spilled to `memory/snapshots/…`, the agent tried `read_file` on the spill and hit:

`Unexpected token '<', "<!DOCTYPE "... is not valid JSON`

Typical cause: the upstream response was an HTML shell (missing Bearer token on Directus `/items/…`), not JSON.

## Solution

1. **`list_digest` for spilled list APIs** — Titles/dates in compact output; model uses digest for list tasks instead of opening spills.
2. **HTML detection end-to-end** — Spill unwrap, `read_file`, compact summaries, and proxy `text` responses surface auth recovery notes instead of raw HTML or parse errors.
3. **Spilled HTML without digest** — Explicit “do not read_file / JSON.parse” when body is HTML even if spill occurred.
4. **Docs** — `http-api` skill, `read_file` tool, turn-continuation nudge aligned with `list_digest` first.

## Testing

- `npm test` — 848 pass
- `npx tsc -b --noEmit` — pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de743bc8-5487-4e11-b73a-87809436f5e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de743bc8-5487-4e11-b73a-87809436f5e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

