### PR TITLE
refactor: dedupe helpers and simplify agent hot paths

### DIFF
--- a/src/agent/adapter.ts
+++ b/src/agent/adapter.ts
@@ -180,7 +180,6 @@ export interface AgentStartOptions {
 }
 
 const agentProcesses = new Map<string, NodeboxProcess>();
-const lastResizes = new Map<string, SpawnPtySize>();
 
 const DEFAULT_PTY: SpawnPtySize = { cols: 120, rows: 40 };
 const STARTUP_TIMEOUT_MS = 20_000;
@@ -367,19 +366,6 @@ function stripWebagentControlMarkerFromStream(
   const data = hold === 0 ? buf : buf.slice(0, -hold);
   const nextCarry = hold === 0 ? "" : buf.slice(-hold);
   return { data, nextCarry };
-}
-
-/**
- * Strip hidden input-ready markers from stdout without newline-gating the whole stream.
- * Newline-based buffering blocked prompt detection: the shell prints `❯ ` with no trailing \n
- * until the user types, so nothing reached promptParseBuffer and the UI stayed "working"/queued.
- */
-function stripWebagentInputReadyFromStream(
-  carry: string,
-  chunk: string,
-  onReady: () => void
-): { data: string; nextCarry: string } {
-  return stripWebagentControlMarkerFromStream(carry, chunk, INPUT_READY_LINE, onReady);
 }
 
 function stripRenderedPrompt(input: string): string {
@@ -957,7 +943,6 @@ export async function startWebAgent(options: AgentStartOptions): Promise<void> {
 
   onOutput("\x1b[38;2;251;117;252m▸ Starting Web Agent…\x1b[0m\n");
 
-  lastResizes.delete(profile.id);
   const agentProcess = await withTimeout(
     spawnProcess("node", [".webagent/agent.js"], {
       env,
@@ -1037,9 +1022,10 @@ export async function startWebAgent(options: AgentStartOptions): Promise<void> {
       }
     );
     awaitingResponseMarkerCarry = awaitingStrip.nextCarry;
-    const { data, nextCarry } = stripWebagentInputReadyFromStream(
+    const { data, nextCarry } = stripWebagentControlMarkerFromStream(
       inputReadyMarkerCarry,
       awaitingStrip.data,
+      INPUT_READY_LINE,
       () => {
         onPromptReady?.();
         scheduleSnapshotSave();
@@ -1125,6 +1111,7 @@ export async function startWebAgent(options: AgentStartOptions): Promise<void> {
       const spawnReqStart = agentOutputBuffer.indexOf(SPAWN_REQ_PREFIX);
       const pythonReqStart = agentOutputBuffer.indexOf(PYTHON_REQ_PREFIX);
       const sttReqStart = agentOutputBuffer.indexOf(STT_REQ_PREFIX);
+      const mcpReqStart = agentOutputBuffer.indexOf(MCP_REQ_PREFIX);
       const fatalStart = agentOutputBuffer.indexOf(FATAL_ERROR_START);
       const nextStartCandidates = [
         profileStart,
@@ -1141,6 +1128,7 @@ export async function startWebAgent(options: AgentStartOptions): Promise<void> {
         spawnReqStart,
         pythonReqStart,
         sttReqStart,
+        mcpReqStart,
         fatalStart,
       ].filter((v) => v >= 0);
       if (nextStartCandidates.length === 0) {
@@ -1717,8 +1705,7 @@ export async function startWebAgent(options: AgentStartOptions): Promise<void> {
       onOutput(`\x1b[31m▸ Agent stopped unexpectedly (exit ${code}). Restart from the sidebar.\x1b[0m\n`);
     }
     agentProcesses.delete(profile.id);
-    lastResizes.delete(profile.id);
-    adapterDebugLogPaths.delete(profile.id);
+      adapterDebugLogPaths.delete(profile.id);
     adapterDebugPending.delete(profile.id);
     adapterDebugFlushPromises.delete(profile.id);
     const timer = adapterDebugFlushTimers.get(profile.id);
@@ -1735,7 +1722,6 @@ export async function stopWebAgent(profileId: string | null): Promise<void> {
   await shutdownMcpHost(profileId).catch(() => {});
   const agentProcess = agentProcesses.get(profileId);
   if (!agentProcess) {
-    lastResizes.delete(profileId);
     return;
   }
   try {
@@ -1753,7 +1739,6 @@ export async function stopWebAgent(profileId: string | null): Promise<void> {
     /* process may already be gone */
   }
   agentProcesses.delete(profileId);
-  lastResizes.delete(profileId);
 }
 
 export async function writeToWebAgent(profileId: string, data: string): Promise<boolean> {

--- a/src/agent/runtime/constants.ts
+++ b/src/agent/runtime/constants.ts
@@ -20,6 +20,10 @@ function envPathOverride(name: string): string {
   return typeof process !== "undefined" ? String(process.env?.[name] || "").trim() : "";
 }
 
+export function isNodeboxRuntime(): boolean {
+  return String(process.env.WEBAGENT_RUNTIME ?? "").trim() === "nodebox";
+}
+
 export function getWorkspaceRoot(): string {
   return envPathOverride("WEBAGENT_WORKSPACE_ROOT") || WS;
 }

--- a/src/agent/runtime/ipc.ts
+++ b/src/agent/runtime/ipc.ts
@@ -275,6 +275,32 @@ export function ipcProxyRequest(request, timeoutMs = 120_000) {
   });
 }
 
+export function readProxyResponse(value: unknown): {
+  status: number;
+  body: string;
+  contentType: string;
+  bodyEncoding?: string;
+  proxyError?: string;
+} {
+  if (value && typeof value === "object") {
+    const rec = value as Record<string, unknown>;
+    const proxyError =
+      typeof rec.error === "string" && rec.error.trim() ? rec.error.trim() : undefined;
+    const status = Number(rec.status);
+    const body = typeof rec.body === "string" ? rec.body : "";
+    const contentType = typeof rec.contentType === "string" ? rec.contentType : "";
+    const bodyEncoding = typeof rec.bodyEncoding === "string" ? rec.bodyEncoding : undefined;
+    return {
+      status: Number.isFinite(status) ? status : 0,
+      body,
+      contentType,
+      bodyEncoding,
+      proxyError,
+    };
+  }
+  return { status: 0, body: "", contentType: "" };
+}
+
 export function ipcProxyStreamRequest(
   request,
   {

--- a/src/agent/runtime/llm/streaming.ts
+++ b/src/agent/runtime/llm/streaming.ts
@@ -8,6 +8,7 @@ import {
   parseToolArguments,
   repairLooseToolCallObject,
 } from "../tools/argument-normalization.js";
+import { levenshtein } from "../utils.js";
 
 type LlmRequestOptions = {
   signal?: AbortSignal;
@@ -45,25 +46,6 @@ type LlmProviderConfig = {
   extraHeaders?: Record<string, string>;
 };
 
-function levenshtein(a: string, b: string): number {
-  const m = a.length;
-  const n = b.length;
-  if (!m) return n;
-  if (!n) return m;
-  const dp = Array.from({ length: m + 1 }, (_, i) => {
-    const row = new Array<number>(n + 1);
-    row[0] = i;
-    return row;
-  });
-  for (let j = 1; j <= n; j++) dp[0][j] = j;
-  for (let i = 1; i <= m; i++) {
-    for (let j = 1; j <= n; j++) {
-      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
-      dp[i][j] = Math.min(dp[i - 1][j] + 1, dp[i][j - 1] + 1, dp[i - 1][j - 1] + cost);
-    }
-  }
-  return dp[m][n];
-}
 
 const SKILL_MANAGE_NAME_ALIASES = new Set([
   "skill_save",

--- a/src/agent/runtime/tools/composio-tools.ts
+++ b/src/agent/runtime/tools/composio-tools.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import nodePath from "node:path";
-import { ipcProxyRequest } from "../ipc.js";
-import { workspaceStatePath, COMPOSIO_AUDIT_REL } from "../constants.js";
+import { ipcProxyRequest, readProxyResponse } from "../ipc.js";
+import { workspaceStatePath, COMPOSIO_AUDIT_REL, isNodeboxRuntime } from "../constants.js";
 import { logDebugEvent } from "../logging/debug-log.js";
 import { createTimeoutController } from "./context.js";
 import { gateToolExecution, summarizeToolApproval } from "./tool-policy.js";
@@ -380,10 +380,6 @@ async function readJsonOrText(res: Response) {
   }
 }
 
-function isNodeboxRuntime() {
-  return String(process.env.WEBAGENT_RUNTIME ?? "").trim() === "nodebox";
-}
-
 function stringifyErrorField(value: unknown): string {
   if (value == null) return "";
   if (typeof value === "string") return value;
@@ -426,12 +422,10 @@ async function composioFetch(ctx, baseUrl: string, path: string, init: RequestIn
       headers,
       body: typeof init.body === "string" ? init.body : init.body ? String(init.body) : null,
     });
-    if (payload?.error) {
-      throw new Error(String(payload.error));
+    const { status, body: bodyText, contentType, proxyError } = readProxyResponse(payload);
+    if (proxyError) {
+      throw new Error(proxyError);
     }
-    const status = Number(payload?.status ?? 0);
-    const bodyText = String(payload?.body ?? "");
-    const contentType = String(payload?.contentType ?? "");
     if (!Number.isFinite(status) || status <= 0) {
       throw new Error(
         `Composio request failed (proxy): unexpected response ${JSON.stringify(payload).slice(0, 240)}`

--- a/src/agent/runtime/tools/email-tools.ts
+++ b/src/agent/runtime/tools/email-tools.ts
@@ -7,7 +7,8 @@
  * matches web_fetch fallback — see remote-tools.js `proxyRequest`.
  */
 
-import { ipcProxyRequest } from "../ipc.js";
+import { ipcProxyRequest, readProxyResponse } from "../ipc.js";
+import { isNodeboxRuntime } from "../constants.js";
 import { gateToolExecution, summarizeToolApproval } from "./tool-policy.js";
 
 const EMAIL_MUTATING = new Set(["send"]);
@@ -26,10 +27,6 @@ function missingResend(cfg) {
   return null;
 }
 
-function isNodeboxRuntime() {
-  return String(process.env.WEBAGENT_RUNTIME ?? "").trim() === "nodebox";
-}
-
 /** POST https://api.resend.com/emails — direct fetch on host Node, IPC proxy in Nodebox. */
 async function postResendEmails(cfg, emailPayload) {
   const url = "https://api.resend.com/emails";
@@ -46,11 +43,10 @@ async function postResendEmails(cfg, emailPayload) {
       headers,
       body: serialized,
     });
-    if (payload?.error) {
-      throw new Error(String(payload.error));
+    const { status, body: bodyText, proxyError } = readProxyResponse(payload);
+    if (proxyError) {
+      throw new Error(proxyError);
     }
-    const status = Number(payload?.status ?? 0);
-    const bodyText = String(payload?.body ?? "");
     if (!Number.isFinite(status) || status <= 0) {
       throw new Error(
         `Resend send failed (proxy): unexpected response ${JSON.stringify(payload).slice(0, 240)}`

--- a/src/agent/runtime/tools/filesystem/path-hints.ts
+++ b/src/agent/runtime/tools/filesystem/path-hints.ts
@@ -76,29 +76,6 @@ function workspaceLayoutHint(input) {
   );
 }
 
-function levenshtein(a, b) {
-  const aa = String(a ?? "");
-  const bb = String(b ?? "");
-  const m = aa.length;
-  const n = bb.length;
-  if (m === 0) return n;
-  if (n === 0) return m;
-  const dp = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0));
-  for (let i = 0; i <= m; i += 1) dp[i][0] = i;
-  for (let j = 0; j <= n; j += 1) dp[0][j] = j;
-  for (let i = 1; i <= m; i += 1) {
-    for (let j = 1; j <= n; j += 1) {
-      const cost = aa[i - 1] === bb[j - 1] ? 0 : 1;
-      dp[i][j] = Math.min(
-        dp[i - 1][j] + 1,
-        dp[i][j - 1] + 1,
-        dp[i - 1][j - 1] + cost
-      );
-    }
-  }
-  return dp[m][n];
-}
-
 export type GrepSearchTarget = {
   absPath: string;
   relPath: string;

--- a/src/agent/runtime/tools/remote-tools.ts
+++ b/src/agent/runtime/tools/remote-tools.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import type { Dirent } from "node:fs";
 import nodePath from "node:path";
 import crypto from "node:crypto";
-import { ipcProxyRequest } from "../ipc.js";
+import { ipcProxyRequest, readProxyResponse } from "../ipc.js";
 import { resolveWorkspacePath, normalizeWorkspaceRelativePath } from "../workspace-paths.js";
 import {
   BROWSER_AGENT_CATALOG_PATH,
@@ -90,31 +90,6 @@ type BrowserCatalogProvider = {
   fetch?: { endpoint?: string; timeoutMs?: number };
 };
 
-function readProxyResponse(value: unknown): {
-  status: number;
-  body: string;
-  contentType: string;
-  bodyEncoding?: string;
-  proxyError?: string;
-} {
-  if (value && typeof value === "object") {
-    const rec = value as Record<string, unknown>;
-    const proxyError =
-      typeof rec.error === "string" && rec.error.trim() ? rec.error.trim() : undefined;
-    const status = Number(rec.status);
-    const body = typeof rec.body === "string" ? rec.body : "";
-    const contentType = typeof rec.contentType === "string" ? rec.contentType : "";
-    const bodyEncoding = typeof rec.bodyEncoding === "string" ? rec.bodyEncoding : undefined;
-    return {
-      status: Number.isFinite(status) ? status : 0,
-      body,
-      contentType,
-      bodyEncoding,
-      proxyError,
-    };
-  }
-  return { status: 0, body: "", contentType: "" };
-}
 
 export function formatProxyTransportError(message: string, url?: string): string {
   const base = String(message || "unknown error").trim() || "unknown error";

--- a/src/agent/runtime/turn.ts
+++ b/src/agent/runtime/turn.ts
@@ -655,14 +655,14 @@ export async function agentTurn(
         estimatedPromptTokens:
           estimateMessagesTokens(conv) + estimateToolSchemaTokens(streamTools),
       });
-      let acc = "";
+      const accChunks: string[] = [];
       let streamedVisible = "";
       const streamWriter = createToolAwareStreamWriter((chunk) => {
         if (!chunk) return;
         streamedVisible += chunk;
       });
       const onDelta = (c) => {
-        acc += c;
+        accChunks.push(c);
         streamWriter.push(c);
       };
       let streamResult;
@@ -686,7 +686,7 @@ export async function agentTurn(
         break;
       }
       streamWriter.flush();
-      const combined = streamResult?.text || acc;
+      const combined = streamResult?.text || accChunks.join("");
       const clarifyParsed = extractClarifyMarkers(combined);
       for (const block of clarifyParsed.blocks) {
         if (mirrorTerminal) process.stdout.write(block);
@@ -1244,7 +1244,7 @@ export async function agentTurn(
       });
       conv.push({
         role: "user",
-        content: "Tool results (compact JSON):\n" + JSON.stringify(summarized, null, 2),
+        content: "Tool results (compact JSON):\n" + JSON.stringify(summarized),
       });
       if (guardrailHalt) {
         const reason = toolGuardrails.haltDecision?.message || "Tool loop guardrail halt";

--- a/src/agent/runtime/utils.ts
+++ b/src/agent/runtime/utils.ts
@@ -3,6 +3,25 @@ export function errorMessage(e: unknown) {
   return String(e);
 }
 
+export function levenshtein(a: string, b: string): number {
+  const aa = String(a ?? "");
+  const bb = String(b ?? "");
+  const m = aa.length;
+  const n = bb.length;
+  if (m === 0) return n;
+  if (n === 0) return m;
+  const dp = Array.from({ length: m + 1 }, () => new Array<number>(n + 1).fill(0));
+  for (let i = 0; i <= m; i += 1) dp[i][0] = i;
+  for (let j = 0; j <= n; j += 1) dp[0][j] = j;
+  for (let i = 1; i <= m; i += 1) {
+    for (let j = 1; j <= n; j += 1) {
+      const cost = aa[i - 1] === bb[j - 1] ? 0 : 1;
+      dp[i][j] = Math.min(dp[i - 1][j] + 1, dp[i][j - 1] + 1, dp[i - 1][j - 1] + cost);
+    }
+  }
+  return dp[m][n];
+}
+
 export function stripAnsi(text: unknown) {
   return String(text || "")
     .replace(/\x1b\[[0-9;]*m/g, "")

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -51,6 +51,8 @@ import { resolveProfileTtsVoice } from "@/core/voice/edge-tts-client";
 import { snapXtermViewportToLatest } from "./terminal-viewport-sync";
 import { maybeTrimTerminalScrollback } from "./terminal-scrollback-gc";
 import { fitTerminalForViewport } from "./xterm-fit-viewport";
+import { formatBytes } from "@/ui/utils/format";
+import { errorMessage } from "@/agent/runtime/utils";
 
 interface OrchestratorAgentState {
   profileId: string;
@@ -86,17 +88,6 @@ function omitDeprecatedCredentialKeys(keys: Record<string, string>): Record<stri
   return out;
 }
 
-function formatBytes(bytes: number): string {
-  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
-  const units = ["B", "KB", "MB", "GB", "TB"];
-  let value = bytes;
-  let unit = 0;
-  while (value >= 1024 && unit < units.length - 1) {
-    value /= 1024;
-    unit += 1;
-  }
-  return `${value >= 10 || unit === 0 ? value.toFixed(0) : value.toFixed(1)} ${units[unit]}`;
-}
 
 function getOrCreateAgentState(profileId: string): OrchestratorAgentState {
   if (!agentStates.has(profileId)) {
@@ -563,7 +554,7 @@ export async function startAgent(profileId?: string): Promise<void> {
       });
       void refreshStorageUsage({ warn: true });
     } catch (err) {
-      const message = (err as Error).message;
+      const message = errorMessage(err);
       write(`\x1b[31m✗ Failed to start: ${message}\x1b[0m\n`);
       const rt = useRuntimeStore.getState();
       rt.setRuntimeStatus(profile.id, "error");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Parallel `/simplify` review of the core agent stack (no local diff; scoped to `adapter`, `turn`, `orchestrator`, and shared runtime utilities). This PR applies surgical deduplication and two correctness/performance fixes without changing behavior.

## Changes

- **Adapter:** Include `MCP_REQ_PREFIX` in IPC marker scan candidates so MCP requests are not skipped when earlier buffer content lacks other markers. Remove unused `lastResizes` map and inline the one-line `stripWebagentInputReadyFromStream` wrapper.
- **Shared utilities:** Add `levenshtein` to `utils.ts`, `isNodeboxRuntime` to `constants.ts`, and `readProxyResponse` to `ipc.ts`; wire composio/email tools and path-hints/streaming/remote-tools to use them.
- **Turn loop:** Accumulate stream deltas in `accChunks[]` + `join("")` instead of `acc += c`; emit compact `JSON.stringify` for tool results (no pretty-print).
- **Orchestrator:** Reuse `formatBytes` from `@/ui/utils/format` and `errorMessage` from runtime utils.

## Verification

- `npx tsc -b --noEmit`
- `npm test` (848 pass, 1 skipped)

## Skipped (recommended follow-ups)

Larger refactors flagged by reviewers but out of scope for a focused pass:

- Deduplicate `writeRuntimeSources` explicit list vs embed-runtime globs (`adapter.ts`)
- Unify tool-arg normalization between `registry.ts` and `streaming.ts`
- Extract repeated `sessionSearchTool` scan logic in `remote-tools.ts`
- Shared workspace byte-read helper in `workspace.ts`
- `resetProfileRuntimeUiState` helper for orchestrator teardown paths
- SSE line parser dedup in `streaming.ts`
- Adapter stdout buffer copy / multi-`indexOf` scan optimizations
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0c22887-3a41-43aa-a1d7-8f328efcd6be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0c22887-3a41-43aa-a1d7-8f328efcd6be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

