### PR TITLE
refactor: tier-1 dedup — embed runtime glob and session search

### DIFF
--- a/src/agent/adapter.ts
+++ b/src/agent/adapter.ts
@@ -40,95 +40,12 @@ import { parseMcpServersConfig, resolveServerConfig } from "@/core/mcp/config";
 import heartbeatSource from "./runtime/HEARTBEAT.md?raw";
 import soulSource from "./runtime/SOUL.md?raw";
 import { TOOL_CATALOG_JSON } from "./tool-catalog";
-import runtimeAgentSource from "../../dist/agent-runtime/agent.js?raw";
-import runtimeConstantsSource from "../../dist/agent-runtime/constants.js?raw";
-import runtimeReflectionSource from "../../dist/agent-runtime/reflection.js?raw";
-import runtimeTurnSequencingSource from "../../dist/agent-runtime/turn-sequencing.js?raw";
-import runtimeTurnContinuationSource from "../../dist/agent-runtime/turn-continuation.js?raw";
-import runtimeStartupContextSource from "../../dist/agent-runtime/startup-context.js?raw";
-import runtimeMemoryGuidanceSource from "../../dist/agent-runtime/memory-guidance.js?raw";
-import runtimeCapabilityRouterSource from "../../dist/agent-runtime/capability-router.js?raw";
-import runtimeToolCapabilityIndexSource from "../../dist/agent-runtime/tool-capability-index.js?raw";
-import runtimeExecutionGuidanceSource from "../../dist/agent-runtime/execution-guidance.js?raw";
-import runtimeUtilsSource from "../../dist/agent-runtime/utils.js?raw";
-import runtimeBootstrapSource from "../../dist/agent-runtime/bootstrap.js?raw";
-import runtimeTurnSource from "../../dist/agent-runtime/turn.js?raw";
-import runtimeSystemPromptCacheSource from "../../dist/agent-runtime/system-prompt-cache.js?raw";
-import runtimeBackgroundReviewSource from "../../dist/agent-runtime/background-review.js?raw";
-import runtimeSkillProvenanceSource from "../../dist/agent-runtime/skill-provenance.js?raw";
-import runtimeCuratorSource from "../../dist/agent-runtime/curator.js?raw";
-import runtimeMessageSanitizerSource from "../../dist/agent-runtime/message-sanitizer.js?raw";
-import runtimeStreamOutputSource from "../../dist/agent-runtime/stream-output.js?raw";
-import runtimeContextCompressionSource from "../../dist/agent-runtime/context-compression.js?raw";
-import runtimePlanningSlashSource from "../../dist/agent-runtime/planning-slash.js?raw";
-import runtimeClarifySlashSource from "../../dist/agent-runtime/clarify-slash.js?raw";
-import runtimeFindSkillsSlashSource from "../../dist/agent-runtime/find-skills-slash.js?raw";
-import runtimeWikiSlashSource from "../../dist/agent-runtime/wiki-slash.js?raw";
-import runtimeSlashRoutingSource from "../../dist/agent-runtime/slash-routing.js?raw";
-import runtimeMcpConfigSource from "../../dist/agent-runtime/mcp-config.js?raw";
-import runtimeMcpRegistrySource from "../../dist/agent-runtime/mcp-registry.js?raw";
-import runtimeTerminalFormatSource from "../../dist/agent-runtime/terminal-format.js?raw";
-import runtimeToolResultPreviewSource from "../../dist/agent-runtime/tool-result-preview.js?raw";
-import runtimeTranscriptSource from "../../dist/agent-runtime/transcript.js?raw";
-import runtimeTranscriptDeliverySource from "../../dist/agent-runtime/transcript-delivery.js?raw";
-import runtimeWorkspacePathsSource from "../../dist/agent-runtime/workspace-paths.js?raw";
-import runtimeArtifactPreviewSource from "../../dist/agent-runtime/artifact-preview.js?raw";
-import runtimeCommandsSource from "../../dist/agent-runtime/commands.js?raw";
-import runtimeSlashCommandViewsSource from "../../dist/agent-runtime/slash-command-views.js?raw";
-import runtimeChannelOutboundSource from "../../dist/agent-runtime/channel-outbound.js?raw";
-import runtimeOnboardingSource from "../../dist/agent-runtime/identity/onboarding.js?raw";
-import runtimeDebugLogSource from "../../dist/agent-runtime/logging/debug-log.js?raw";
-import runtimePrivacySource from "../../dist/agent-runtime/privacy.js?raw";
 import { normalizeLaunchMode, sanitizeForLogs } from "./runtime/privacy";
-import runtimeMemorySource from "../../dist/agent-runtime/memory/index.js?raw";
-import runtimeMemorySqlSource from "../../dist/agent-runtime/memory/sql.js?raw";
-import runtimeMemoryRunsSource from "../../dist/agent-runtime/memory/runs.js?raw";
-import runtimeMemoryJobsSource from "../../dist/agent-runtime/memory/jobs.js?raw";
-import runtimeMemorySnapshotsSource from "../../dist/agent-runtime/memory/snapshots.js?raw";
-import runtimeMemoryInternalPathsSource from "../../dist/agent-runtime/memory/internal-paths.js?raw";
-import runtimeMemoryReflectionSource from "../../dist/agent-runtime/memory/reflection.js?raw";
-import runtimeMemoryFactsSource from "../../dist/agent-runtime/memory/facts.js?raw";
-import runtimeMemorySemanticIndexSource from "../../dist/agent-runtime/memory/semantic-index.js?raw";
-import runtimeMemoryToolStatsSource from "../../dist/agent-runtime/memory/tool-stats.js?raw";
-import runtimeMemoryLearningsSource from "../../dist/agent-runtime/memory/learnings.js?raw";
-import runtimeMemorySkillsSource from "../../dist/agent-runtime/memory/skills.js?raw";
-import runtimeMemorySkillCompatSource from "../../dist/agent-runtime/memory/skill-compat.js?raw";
-import runtimeMemorySkillImportUrlSource from "../../dist/agent-runtime/memory/skill-import-url.js?raw";
-import runtimeMemoryContextBlocksSource from "../../dist/agent-runtime/memory/context-blocks.js?raw";
-/** Nodebox copies this string at agent start — it is `dist/`, not `src/`; run `npm run build:embed-runtime` after changing runtime TS. */
-import runtimePersistenceSource from "../../dist/agent-runtime/state/persistence.js?raw";
-import runtimeMigrationsIndexSource from "../../dist/agent-runtime/migrations/index.js?raw";
-import runtimeMigrationsTypesSource from "../../dist/agent-runtime/migrations/types.js?raw";
-import runtimeMigrationsStateSource from "../../dist/agent-runtime/migrations/state.js?raw";
-import runtimeMigrationsRunnerSource from "../../dist/agent-runtime/migrations/runner.js?raw";
-import runtimeMigrationsRegistrySource from "../../dist/agent-runtime/migrations/registry.js?raw";
-import runtimeMigration001Source from "../../dist/agent-runtime/migrations/001-relocate-state-files.js?raw";
-import runtimeMigrationsNotifySource from "../../dist/agent-runtime/migrations/notify.js?raw";
-import runtimeChannelDispatcherSource from "../../dist/agent-runtime/channels/dispatcher.js?raw";
-import runtimeChannelIndexSource from "../../dist/agent-runtime/channels/index.js?raw";
-import runtimeChannelTelegramSource from "../../dist/agent-runtime/channels/telegram.js?raw";
-import runtimeChannelTelegramFilesSource from "../../dist/agent-runtime/channels/telegram-files.js?raw";
-import runtimeTelegramVoiceSource from "../../dist/agent-runtime/voice/telegram-voice.js?raw";
-import runtimeIpcSource from "../../dist/agent-runtime/ipc.js?raw";
-import runtimeUserInputFramingSource from "../../dist/agent-runtime/user-input-framing.js?raw";
-import runtimeCronSchedulingSource from "../../dist/agent-runtime/cron-scheduling.js?raw";
 import sqlWasmRuntimeSource from "sql.js/dist/sql-wasm.js?raw";
 import sqlWasmUrl from "sql.js/dist/sql-wasm.wasm?url";
 
-const runtimeToolSources = import.meta.glob("../../dist/agent-runtime/tools/**/*.js", {
-  eager: true,
-  query: "?raw",
-  import: "default",
-}) as Record<string, string>;
-
-const runtimeLlmModuleSources = import.meta.glob("../../dist/agent-runtime/llm/**/*.js", {
-  eager: true,
-  query: "?raw",
-  import: "default",
-}) as Record<string, string>;
-
-/** Root-level runtime modules (e.g. cron-scheduling.js) — not under tools/. */
-const runtimeRootModuleSources = import.meta.glob("../../dist/agent-runtime/*.js", {
+/** Built embed-runtime tree — single source for Nodebox copy (run `npm run build:embed-runtime` after TS edits). */
+const runtimeModuleSources = import.meta.glob("../../dist/agent-runtime/**/*.js", {
   eager: true,
   query: "?raw",
   import: "default",
@@ -474,109 +391,22 @@ async function writeRuntimeSources(profileId: string): Promise<void> {
   const webagentDir = `/workspace/${profileId}/.webagent`;
 
   await emulator.fs.mkdir(webagentDir, { recursive: true });
-  await emulator.fs.mkdir(`${webagentDir}/identity`, { recursive: true });
-  await emulator.fs.mkdir(`${webagentDir}/llm`, { recursive: true });
-  await emulator.fs.mkdir(`${webagentDir}/logging`, { recursive: true });
-  await emulator.fs.mkdir(`${webagentDir}/memory`, { recursive: true });
-  await emulator.fs.mkdir(`${webagentDir}/migrations`, { recursive: true });
-  await emulator.fs.mkdir(`${webagentDir}/state`, { recursive: true });
-  await emulator.fs.mkdir(`${webagentDir}/tools`, { recursive: true });
-  await emulator.fs.mkdir(`${webagentDir}/channels`, { recursive: true });
-  await emulator.fs.mkdir(`${webagentDir}/voice`, { recursive: true });
-  await emulator.fs.mkdir(`${webagentDir}/capabilities`, { recursive: true });
   await emulator.fs.mkdir(`${webagentDir}/vendor`, { recursive: true });
 
-  // Required so Node.js treats .js files in this directory as ESM.
   await emulator.fs.writeFile(
     `${webagentDir}/package.json`,
     JSON.stringify({ name: "@webagent/runtime", private: true, type: "module" })
   );
 
-  await emulator.fs.writeFile(`${webagentDir}/ipc.js`, runtimeIpcSource);
-  await emulator.fs.writeFile(`${webagentDir}/user-input-framing.js`, runtimeUserInputFramingSource);
-  await emulator.fs.writeFile(`${webagentDir}/agent.js`, runtimeAgentSource);
-  await emulator.fs.writeFile(`${webagentDir}/constants.js`, runtimeConstantsSource);
-  await emulator.fs.writeFile(`${webagentDir}/reflection.js`, runtimeReflectionSource);
-  await emulator.fs.writeFile(`${webagentDir}/turn-sequencing.js`, runtimeTurnSequencingSource);
-  await emulator.fs.writeFile(`${webagentDir}/turn-continuation.js`, runtimeTurnContinuationSource);
-  await emulator.fs.writeFile(`${webagentDir}/startup-context.js`, runtimeStartupContextSource);
-  await emulator.fs.writeFile(`${webagentDir}/memory-guidance.js`, runtimeMemoryGuidanceSource);
-  await emulator.fs.writeFile(`${webagentDir}/capability-router.js`, runtimeCapabilityRouterSource);
-  await emulator.fs.writeFile(`${webagentDir}/tool-capability-index.js`, runtimeToolCapabilityIndexSource);
-  await emulator.fs.writeFile(`${webagentDir}/execution-guidance.js`, runtimeExecutionGuidanceSource);
-  await emulator.fs.writeFile(`${webagentDir}/utils.js`, runtimeUtilsSource);
-  await emulator.fs.writeFile(`${webagentDir}/bootstrap.js`, runtimeBootstrapSource);
-  await emulator.fs.writeFile(`${webagentDir}/turn.js`, runtimeTurnSource);
-  await emulator.fs.writeFile(`${webagentDir}/system-prompt-cache.js`, runtimeSystemPromptCacheSource);
-  await emulator.fs.writeFile(`${webagentDir}/background-review.js`, runtimeBackgroundReviewSource);
-  await emulator.fs.writeFile(`${webagentDir}/skill-provenance.js`, runtimeSkillProvenanceSource);
-  await emulator.fs.writeFile(`${webagentDir}/curator.js`, runtimeCuratorSource);
-  await emulator.fs.writeFile(`${webagentDir}/message-sanitizer.js`, runtimeMessageSanitizerSource);
-  await emulator.fs.writeFile(`${webagentDir}/stream-output.js`, runtimeStreamOutputSource);
-  await emulator.fs.writeFile(`${webagentDir}/context-compression.js`, runtimeContextCompressionSource);
-  await emulator.fs.writeFile(`${webagentDir}/planning-slash.js`, runtimePlanningSlashSource);
-  await emulator.fs.writeFile(`${webagentDir}/find-skills-slash.js`, runtimeFindSkillsSlashSource);
-  await emulator.fs.writeFile(`${webagentDir}/wiki-slash.js`, runtimeWikiSlashSource);
-  await emulator.fs.writeFile(`${webagentDir}/slash-routing.js`, runtimeSlashRoutingSource);
-  await emulator.fs.writeFile(`${webagentDir}/mcp-config.js`, runtimeMcpConfigSource);
-  await emulator.fs.writeFile(`${webagentDir}/mcp-registry.js`, runtimeMcpRegistrySource);
-  await emulator.fs.writeFile(`${webagentDir}/terminal-format.js`, runtimeTerminalFormatSource);
-  await emulator.fs.writeFile(`${webagentDir}/tool-result-preview.js`, runtimeToolResultPreviewSource);
-  await emulator.fs.writeFile(`${webagentDir}/transcript.js`, runtimeTranscriptSource);
-  await emulator.fs.writeFile(`${webagentDir}/transcript-delivery.js`, runtimeTranscriptDeliverySource);
-  await emulator.fs.writeFile(`${webagentDir}/commands.js`, runtimeCommandsSource);
-  await emulator.fs.writeFile(`${webagentDir}/slash-command-views.js`, runtimeSlashCommandViewsSource);
-  await emulator.fs.writeFile(`${webagentDir}/channel-outbound.js`, runtimeChannelOutboundSource);
-  await emulator.fs.writeFile(`${webagentDir}/workspace-paths.js`, runtimeWorkspacePathsSource);
-  await emulator.fs.writeFile(`${webagentDir}/artifact-preview.js`, runtimeArtifactPreviewSource);
-  await emulator.fs.writeFile(`${webagentDir}/privacy.js`, runtimePrivacySource);
-  await emulator.fs.writeFile(`${webagentDir}/identity/onboarding.js`, runtimeOnboardingSource);
-  await emulator.fs.writeFile(`${webagentDir}/logging/debug-log.js`, runtimeDebugLogSource);
-  await emulator.fs.writeFile(`${webagentDir}/memory/index.js`, runtimeMemorySource);
-  await emulator.fs.writeFile(`${webagentDir}/memory/sql.js`, runtimeMemorySqlSource);
-  await emulator.fs.writeFile(`${webagentDir}/memory/runs.js`, runtimeMemoryRunsSource);
-  await emulator.fs.writeFile(`${webagentDir}/memory/jobs.js`, runtimeMemoryJobsSource);
-  await emulator.fs.writeFile(`${webagentDir}/memory/internal-paths.js`, runtimeMemoryInternalPathsSource);
-  await emulator.fs.writeFile(`${webagentDir}/memory/snapshots.js`, runtimeMemorySnapshotsSource);
-  await emulator.fs.writeFile(`${webagentDir}/memory/reflection.js`, runtimeMemoryReflectionSource);
-  await emulator.fs.writeFile(`${webagentDir}/memory/facts.js`, runtimeMemoryFactsSource);
-  await emulator.fs.writeFile(`${webagentDir}/memory/semantic-index.js`, runtimeMemorySemanticIndexSource);
-  await emulator.fs.writeFile(`${webagentDir}/memory/tool-stats.js`, runtimeMemoryToolStatsSource);
-  await emulator.fs.writeFile(`${webagentDir}/memory/learnings.js`, runtimeMemoryLearningsSource);
-  await emulator.fs.writeFile(`${webagentDir}/memory/skills.js`, runtimeMemorySkillsSource);
-  await emulator.fs.writeFile(`${webagentDir}/memory/skill-compat.js`, runtimeMemorySkillCompatSource);
-  await emulator.fs.writeFile(`${webagentDir}/memory/skill-import-url.js`, runtimeMemorySkillImportUrlSource);
-  await emulator.fs.writeFile(`${webagentDir}/memory/context-blocks.js`, runtimeMemoryContextBlocksSource);
-  await emulator.fs.writeFile(`${webagentDir}/migrations/index.js`, runtimeMigrationsIndexSource);
-  await emulator.fs.writeFile(`${webagentDir}/migrations/types.js`, runtimeMigrationsTypesSource);
-  await emulator.fs.writeFile(`${webagentDir}/migrations/state.js`, runtimeMigrationsStateSource);
-  await emulator.fs.writeFile(`${webagentDir}/migrations/runner.js`, runtimeMigrationsRunnerSource);
-  await emulator.fs.writeFile(`${webagentDir}/migrations/registry.js`, runtimeMigrationsRegistrySource);
-  await emulator.fs.writeFile(`${webagentDir}/migrations/001-relocate-state-files.js`, runtimeMigration001Source);
-  await emulator.fs.writeFile(`${webagentDir}/migrations/notify.js`, runtimeMigrationsNotifySource);
-  await emulator.fs.writeFile(`${webagentDir}/state/persistence.js`, runtimePersistenceSource);
-  await emulator.fs.writeFile(`${webagentDir}/cron-scheduling.js`, runtimeCronSchedulingSource);
-  for (const [sourcePath, content] of Object.entries(runtimeRootModuleSources)) {
+  for (const [sourcePath, content] of Object.entries(runtimeModuleSources)) {
     const rel = sourcePath.replace(/^.*dist\/agent-runtime\//, "");
-    await emulator.fs.writeFile(`${webagentDir}/${rel}`, content);
-  }
-  for (const [sourcePath, content] of Object.entries(runtimeToolSources)) {
-    const rel = sourcePath.replace(/^.*dist\/agent-runtime\/tools\//, "tools/");
+    if (!rel) continue;
+    const target = `${webagentDir}/${rel}`;
     const parent = rel.split("/").slice(0, -1).join("/");
     if (parent) await emulator.fs.mkdir(`${webagentDir}/${parent}`, { recursive: true });
-    await emulator.fs.writeFile(`${webagentDir}/${rel}`, content);
+    await emulator.fs.writeFile(target, content);
   }
-  for (const [sourcePath, content] of Object.entries(runtimeLlmModuleSources)) {
-    const rel = sourcePath.replace(/^.*dist\/agent-runtime\//, "");
-    const parent = rel.split("/").slice(0, -1).join("/");
-    if (parent) await emulator.fs.mkdir(`${webagentDir}/${parent}`, { recursive: true });
-    await emulator.fs.writeFile(`${webagentDir}/${rel}`, content);
-  }
-  await emulator.fs.writeFile(`${webagentDir}/channels/telegram.js`, runtimeChannelTelegramSource);
-  await emulator.fs.writeFile(`${webagentDir}/channels/telegram-files.js`, runtimeChannelTelegramFilesSource);
-  await emulator.fs.writeFile(`${webagentDir}/channels/dispatcher.js`, runtimeChannelDispatcherSource);
-  await emulator.fs.writeFile(`${webagentDir}/channels/index.js`, runtimeChannelIndexSource);
-  await emulator.fs.writeFile(`${webagentDir}/voice/telegram-voice.js`, runtimeTelegramVoiceSource);
+
   await emulator.fs.writeFile(`${webagentDir}/vendor/sql-wasm.cjs`, sqlWasmRuntimeSource);
 
   const sqlWasmResponse = await fetch(sqlWasmUrl);

--- a/src/agent/runtime/tools/remote-tools.ts
+++ b/src/agent/runtime/tools/remote-tools.ts
@@ -1252,6 +1252,14 @@ const SESSION_SEARCH_RECENCY_QUERY_RE =
 const SESSION_SEARCH_RECENCY_ONLY_RE =
   /^(?:recent|latest|last|prior|previous)(?:\s+(?:session|sessions|work|chat|conversation|thread|messages?))?s?$/i;
 
+type SessionSearchHit = {
+  score: number;
+  id: string;
+  snippet: string;
+  relPath: string;
+  mtime: number;
+};
+
 function isRecencyOnlySessionSearchQuery(query) {
   const q = String(query || "").trim();
   if (!q) return true;
@@ -1275,6 +1283,116 @@ function firstTokenOffset(haystackLc, tokens) {
   return best;
 }
 
+function sessionSearchTokenScore(low, tokens) {
+  let score = 0;
+  for (const t of tokens) {
+    if (low.includes(t)) score += 1;
+  }
+  return score;
+}
+
+function sessionSearchSnippet(searchable, tokens) {
+  const maxLen = SESSION_SEARCH_CONTEXT * 2;
+  const off = firstTokenOffset(searchable.toLowerCase(), tokens);
+  if (off < 0) return searchable.slice(0, maxLen);
+  const start = Math.max(0, off - SESSION_SEARCH_CONTEXT);
+  const end = Math.min(searchable.length, off + SESSION_SEARCH_CONTEXT);
+  let snippet = searchable.slice(start, end);
+  if (start > 0) snippet = "…" + snippet;
+  if (end < searchable.length) snippet = snippet + "…";
+  return snippet;
+}
+
+function appendSessionSearchHits(
+  scored,
+  recentCandidates,
+  searchable,
+  tokens,
+  recencyOnly,
+  recencyQuery,
+  id,
+  relPath,
+  mtime,
+  offsetRecencySnippet = true
+) {
+  const low = searchable.toLowerCase();
+  const score = sessionSearchTokenScore(low, tokens);
+  const headSnippet = searchable.slice(0, SESSION_SEARCH_CONTEXT * 2);
+  if (recencyOnly) {
+    recentCandidates.push({ score: 0, id, snippet: headSnippet, relPath, mtime });
+    return;
+  }
+  if (score === 0) {
+    if (recencyQuery) {
+      let snippet = headSnippet;
+      if (offsetRecencySnippet && tokens.length) {
+        snippet = sessionSearchSnippet(searchable, tokens);
+      }
+      recentCandidates.push({ score: 0, id, snippet, relPath, mtime });
+    }
+    return;
+  }
+  const snippet = sessionSearchSnippet(searchable, tokens);
+  scored.push({ score, id, snippet, relPath, mtime });
+  if (recencyQuery) {
+    recentCandidates.push({ score: 0, id, snippet, relPath, mtime });
+  }
+}
+
+async function listRecentJsonFiles(absDir, maxFiles) {
+  let dirents = [];
+  try {
+    dirents = await fs.readdir(absDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const jsonFiles = dirents.filter((e) => e.isFile() && e.name.endsWith(".json"));
+  const withMtime = await Promise.all(
+    jsonFiles.map(async (e) => {
+      const abs = nodePath.join(absDir, e.name);
+      const st = await fs.stat(abs).catch(() => null);
+      return { abs, name: e.name, mtime: st?.mtimeMs || 0 };
+    })
+  );
+  withMtime.sort((a, b) => b.mtime - a.mtime);
+  return withMtime.slice(0, maxFiles);
+}
+
+function runSearchableFromRunJson(raw) {
+  let id = "";
+  let searchable = "";
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object") {
+      if (parsed.id) id = String(parsed.id);
+      const toolNames = Array.isArray(parsed.tool_calls)
+        ? parsed.tool_calls
+            .map((item) =>
+              item && typeof item === "object" && item.name ? String(item.name) : ""
+            )
+            .filter(Boolean)
+            .join(" ")
+        : "";
+      const errors = Array.isArray(parsed.errors)
+        ? parsed.errors.map((v) => String(v || "")).join(" ")
+        : "";
+      searchable = [
+        String(parsed.goal || ""),
+        String(parsed.input || ""),
+        String(parsed.final_visible_assistant_text || ""),
+        toolNames,
+        errors,
+      ]
+        .join(" ")
+        .replace(/\s+/g, " ")
+        .trim();
+    }
+  } catch {
+    searchable = raw.replace(/\s+/g, " ").trim();
+  }
+  return { id, searchable };
+}
+
 /** Full-text search persisted conversation JSON files (memory/conversations). */
 export async function sessionSearchTool(args: ToolArgs = {}, _ctx) {
   const query = typeof args?.query === "string" ? args.query.trim() : "";
@@ -1292,34 +1410,10 @@ export async function sessionSearchTool(args: ToolArgs = {}, _ctx) {
   const absDir = memoryPath(MEMORY_CONVERSATIONS_DIR);
   const absRunsDir = memoryPath(MEMORY_RUNS_DIR);
   const sessionMemoryPath = workspaceStatePath(".webagent/session-memory.jsonl");
-  type SessionSearchHit = {
-    score: number;
-    id: string;
-    snippet: string;
-    relPath: string;
-    mtime: number;
-  };
-  const scored: SessionSearchHit[] = [];
-  const recentCandidates: SessionSearchHit[] = [];
+  const scored = [];
+  const recentCandidates = [];
 
-  let dirents: Dirent[] = [];
-  try {
-    dirents = await fs.readdir(absDir, { withFileTypes: true });
-  } catch {
-    /* fall through to run/session-memory fallbacks */
-  }
-
-  const jsonFiles = dirents.filter((e) => e.isFile() && e.name.endsWith(".json"));
-  const withMtime = await Promise.all(
-    jsonFiles.map(async (e) => {
-      const abs = nodePath.join(absDir, e.name);
-      const st = await fs.stat(abs).catch(() => null);
-      return { abs, name: e.name, mtime: st?.mtimeMs || 0 };
-    })
-  );
-  withMtime.sort((a, b) => b.mtime - a.mtime);
-  const toScan = withMtime.slice(0, maxFiles);
-
+  const toScan = await listRecentJsonFiles(absDir, maxFiles);
   for (const { abs, name, mtime } of toScan) {
     let raw;
     try {
@@ -1329,88 +1423,30 @@ export async function sessionSearchTool(args: ToolArgs = {}, _ctx) {
     }
     let id = name.replace(/\.json$/i, "");
     const text = raw.replace(/\s+/g, " ").trim();
-    const low = text.toLowerCase();
-    let score = 0;
-    for (const t of tokens) {
-      if (low.includes(t)) score += 1;
-    }
-    if (recencyOnly) {
-      recentCandidates.push({
-        score: 0,
-        id,
-        snippet: text.slice(0, SESSION_SEARCH_CONTEXT * 2),
-        relPath: `memory/conversations/${name}`,
-        mtime,
-      });
-      continue;
-    }
-    if (score === 0) {
-      if (recencyQuery) {
-        const recencySnippet = text.slice(0, SESSION_SEARCH_CONTEXT * 2);
-        recentCandidates.push({
-          score: 0,
-          id,
-          snippet: recencySnippet,
-          relPath: `memory/conversations/${name}`,
-          mtime,
-        });
+    const score = sessionSearchTokenScore(text.toLowerCase(), tokens);
+    if (!recencyOnly && score > 0) {
+      try {
+        const parsed = JSON.parse(raw);
+        if (parsed && typeof parsed === "object" && parsed.id) id = String(parsed.id);
+      } catch {
+        /* keep basename */
       }
-      continue;
     }
-
-    try {
-      const parsed = JSON.parse(raw);
-      if (parsed && typeof parsed === "object" && parsed.id) id = String(parsed.id);
-    } catch {
-      /* keep basename */
-    }
-
-    const off = firstTokenOffset(low, tokens);
-    let snippet = text.slice(0, SESSION_SEARCH_CONTEXT * 2);
-    if (off >= 0) {
-      const start = Math.max(0, off - SESSION_SEARCH_CONTEXT);
-      const end = Math.min(text.length, off + SESSION_SEARCH_CONTEXT);
-      snippet = text.slice(start, end);
-      if (start > 0) snippet = "…" + snippet;
-      if (end < text.length) snippet = snippet + "…";
-    }
-
-    scored.push({
-      score,
+    appendSessionSearchHits(
+      scored,
+      recentCandidates,
+      text,
+      tokens,
+      recencyOnly,
+      recencyQuery,
       id,
-      snippet,
-      relPath: `memory/conversations/${name}`,
+      `memory/conversations/${name}`,
       mtime,
-    });
-    if (recencyQuery) {
-      recentCandidates.push({
-        score: 0,
-        id,
-        snippet,
-        relPath: `memory/conversations/${name}`,
-        mtime,
-      });
-    }
+      false
+    );
   }
 
-  // Fallback 1: run history snapshots (saved each turn).
-  let runDirents: Dirent[] = [];
-  try {
-    runDirents = await fs.readdir(absRunsDir, { withFileTypes: true });
-  } catch {
-    /* absent */
-  }
-  const runFiles = runDirents.filter((e) => e.isFile() && e.name.endsWith(".json"));
-  const runWithMtime = await Promise.all(
-    runFiles.map(async (e) => {
-      const abs = nodePath.join(absRunsDir, e.name);
-      const st = await fs.stat(abs).catch(() => null);
-      return { abs, name: e.name, mtime: st?.mtimeMs || 0 };
-    })
-  );
-  runWithMtime.sort((a, b) => b.mtime - a.mtime);
-  const runToScan = runWithMtime.slice(0, maxFiles);
-
+  const runToScan = await listRecentJsonFiles(absRunsDir, maxFiles);
   for (const { abs, name, mtime } of runToScan) {
     let raw = "";
     try {
@@ -1419,101 +1455,22 @@ export async function sessionSearchTool(args: ToolArgs = {}, _ctx) {
       continue;
     }
     let id = name.replace(/\.json$/i, "");
-    let searchable = "";
-    try {
-      const parsed = JSON.parse(raw);
-      if (parsed && typeof parsed === "object") {
-        if (parsed.id) id = String(parsed.id);
-        const toolNames = Array.isArray(parsed.tool_calls)
-          ? parsed.tool_calls
-              .map((item) =>
-                item && typeof item === "object" && item.name ? String(item.name) : ""
-              )
-              .filter(Boolean)
-              .join(" ")
-          : "";
-        const errors = Array.isArray(parsed.errors)
-          ? parsed.errors.map((v) => String(v || "")).join(" ")
-          : "";
-        searchable = [
-          String(parsed.goal || ""),
-          String(parsed.input || ""),
-          String(parsed.final_visible_assistant_text || ""),
-          toolNames,
-          errors,
-        ]
-          .join(" ")
-          .replace(/\s+/g, " ")
-          .trim();
-      }
-    } catch {
-      searchable = raw.replace(/\s+/g, " ").trim();
-    }
-    if (!searchable) continue;
-    const low = searchable.toLowerCase();
-    let score = 0;
-    for (const t of tokens) {
-      if (low.includes(t)) score += 1;
-    }
-    if (recencyOnly) {
-      recentCandidates.push({
-        score: 0,
-        id,
-        snippet: searchable.slice(0, SESSION_SEARCH_CONTEXT * 2),
-        relPath: `memory/runs/${name}`,
-        mtime,
-      });
-      continue;
-    }
-    if (score === 0) {
-      if (recencyQuery) {
-        const offAny = firstTokenOffset(low, tokens);
-        let recencySnippet = searchable.slice(0, SESSION_SEARCH_CONTEXT * 2);
-        if (offAny >= 0) {
-          const start = Math.max(0, offAny - SESSION_SEARCH_CONTEXT);
-          const end = Math.min(searchable.length, offAny + SESSION_SEARCH_CONTEXT);
-          recencySnippet = searchable.slice(start, end);
-          if (start > 0) recencySnippet = "…" + recencySnippet;
-          if (end < searchable.length) recencySnippet = recencySnippet + "…";
-        }
-        recentCandidates.push({
-          score: 0,
-          id,
-          snippet: recencySnippet,
-          relPath: `memory/runs/${name}`,
-          mtime,
-        });
-      }
-      continue;
-    }
-    const off = firstTokenOffset(low, tokens);
-    let snippet = searchable.slice(0, SESSION_SEARCH_CONTEXT * 2);
-    if (off >= 0) {
-      const start = Math.max(0, off - SESSION_SEARCH_CONTEXT);
-      const end = Math.min(searchable.length, off + SESSION_SEARCH_CONTEXT);
-      snippet = searchable.slice(start, end);
-      if (start > 0) snippet = "…" + snippet;
-      if (end < searchable.length) snippet = snippet + "…";
-    }
-    scored.push({
-      score,
+    const parsed = runSearchableFromRunJson(raw);
+    if (parsed.id) id = parsed.id;
+    if (!parsed.searchable) continue;
+    appendSessionSearchHits(
+      scored,
+      recentCandidates,
+      parsed.searchable,
+      tokens,
+      recencyOnly,
+      recencyQuery,
       id,
-      snippet,
-      relPath: `memory/runs/${name}`,
-      mtime,
-    });
-    if (recencyQuery) {
-      recentCandidates.push({
-        score: 0,
-        id,
-        snippet,
-        relPath: `memory/runs/${name}`,
-        mtime,
-      });
-    }
+      `memory/runs/${name}`,
+      mtime
+    );
   }
 
-  // Fallback 2: rolling session-memory notes.
   try {
     const [raw, stat] = await Promise.all([
       fs.readFile(sessionMemoryPath, "utf8"),
@@ -1537,68 +1494,18 @@ export async function sessionSearchTool(args: ToolArgs = {}, _ctx) {
         .replace(/\s+/g, " ")
         .trim();
       if (!searchable) continue;
-      const low = searchable.toLowerCase();
-      let score = 0;
-      for (const t of tokens) {
-        if (low.includes(t)) score += 1;
-      }
       const rowTs = Date.parse(String(row?.ts || ""));
-      if (recencyOnly) {
-        recentCandidates.push({
-          score: 0,
-          id: String(row?.ts || "session-memory"),
-          snippet: searchable.slice(0, SESSION_SEARCH_CONTEXT * 2),
-          relPath: ".webagent/session-memory.jsonl",
-          mtime: Number.isFinite(rowTs) ? rowTs : stat?.mtimeMs || 0,
-        });
-        continue;
-      }
-      if (score === 0) {
-        if (recencyQuery) {
-          const offAny = firstTokenOffset(low, tokens);
-          let recencySnippet = searchable.slice(0, SESSION_SEARCH_CONTEXT * 2);
-          if (offAny >= 0) {
-            const start = Math.max(0, offAny - SESSION_SEARCH_CONTEXT);
-            const end = Math.min(searchable.length, offAny + SESSION_SEARCH_CONTEXT);
-            recencySnippet = searchable.slice(start, end);
-            if (start > 0) recencySnippet = "…" + recencySnippet;
-            if (end < searchable.length) recencySnippet = recencySnippet + "…";
-          }
-          recentCandidates.push({
-            score: 0,
-            id: String(row?.ts || "session-memory"),
-            snippet: recencySnippet,
-            relPath: ".webagent/session-memory.jsonl",
-            mtime: Number.isFinite(rowTs) ? rowTs : stat?.mtimeMs || 0,
-          });
-        }
-        continue;
-      }
-      const off = firstTokenOffset(low, tokens);
-      let snippet = searchable.slice(0, SESSION_SEARCH_CONTEXT * 2);
-      if (off >= 0) {
-        const start = Math.max(0, off - SESSION_SEARCH_CONTEXT);
-        const end = Math.min(searchable.length, off + SESSION_SEARCH_CONTEXT);
-        snippet = searchable.slice(start, end);
-        if (start > 0) snippet = "…" + snippet;
-        if (end < searchable.length) snippet = snippet + "…";
-      }
-      scored.push({
-        score,
-        id: String(row?.ts || "session-memory"),
-        snippet,
-        relPath: ".webagent/session-memory.jsonl",
-        mtime: Number.isFinite(rowTs) ? rowTs : stat?.mtimeMs || 0,
-      });
-      if (recencyQuery) {
-        recentCandidates.push({
-          score: 0,
-          id: String(row?.ts || "session-memory"),
-          snippet,
-          relPath: ".webagent/session-memory.jsonl",
-          mtime: Number.isFinite(rowTs) ? rowTs : stat?.mtimeMs || 0,
-        });
-      }
+      appendSessionSearchHits(
+        scored,
+        recentCandidates,
+        searchable,
+        tokens,
+        recencyOnly,
+        recencyQuery,
+        String(row?.ts || "session-memory"),
+        ".webagent/session-memory.jsonl",
+        Number.isFinite(rowTs) ? rowTs : stat?.mtimeMs || 0
+      );
     }
   } catch {
     /* absent */
@@ -1607,7 +1514,7 @@ export async function sessionSearchTool(args: ToolArgs = {}, _ctx) {
   scored.sort((a, b) => b.score - a.score || b.mtime - a.mtime);
   let top = scored.slice(0, 3);
   if (top.length === 0 && recencyQuery && recentCandidates.length > 0) {
-    const uniqueByPath = new Map<string, SessionSearchHit>();
+    const uniqueByPath = new Map();
     for (const item of recentCandidates) {
       const existing = uniqueByPath.get(item.relPath);
       if (!existing || existing.mtime < item.mtime) uniqueByPath.set(item.relPath, item);

--- a/tests/context-compression.test.ts
+++ b/tests/context-compression.test.ts
@@ -244,26 +244,11 @@ test("adapter injects every bootstrap static ./ import (runtime entry pulls the 
   ].map((match) => match[1]);
 
   assert.ok(runtimeImports.includes("context-compression.js"));
-  for (const runtimeImport of runtimeImports) {
-    if (runtimeImport.startsWith("tools/")) {
-      assert.ok(
-        adapterSource.includes("../../dist/agent-runtime/tools/**/*.js"),
-        `adapter must glob-copy ${runtimeImport} into .webagent`
-      );
-      continue;
-    }
-    if (runtimeImport.startsWith("llm/")) {
-      assert.ok(
-        adapterSource.includes("../../dist/agent-runtime/llm/**/*.js"),
-        `adapter must glob-copy ${runtimeImport} into .webagent`
-      );
-      continue;
-    }
-    assert.ok(
-      adapterSource.includes(`\${webagentDir}/${runtimeImport}`),
-      `adapter must write ${runtimeImport} into .webagent`
-    );
-  }
+  assert.ok(
+    adapterSource.includes("../../dist/agent-runtime/**/*.js"),
+    "adapter must glob-copy the full embed-runtime tree into .webagent"
+  );
+  assert.ok(adapterSource.includes("runtimeModuleSources"));
 });
 
 test("adapter mirrors turn.js static runtime imports into .webagent", async () => {
@@ -277,20 +262,8 @@ test("adapter mirrors turn.js static runtime imports into .webagent", async () =
   ].map((match) => match[1]);
 
   assert.ok(runtimeImports.includes("message-sanitizer.js"));
-  for (const runtimeImport of runtimeImports) {
-    if (runtimeImport.startsWith("tools/")) continue;
-    if (runtimeImport.startsWith("llm/")) {
-      assert.ok(
-        adapterSource.includes("../../dist/agent-runtime/llm/**/*.js"),
-        `adapter must glob-copy ${runtimeImport} into .webagent`
-      );
-      continue;
-    }
-    assert.ok(
-      adapterSource.includes(`\${webagentDir}/${runtimeImport}`),
-      `adapter must write ${runtimeImport} into .webagent`
-    );
-  }
+  assert.ok(adapterSource.includes("../../dist/agent-runtime/**/*.js"));
+  assert.ok(adapterSource.includes("runtimeModuleSources"));
 });
 
 test("pruneConversationForMidTurn collapses old tool JSON when above 80% window", () => {
@@ -314,9 +287,7 @@ test("pruneConversationForMidTurn collapses old tool JSON when above 80% window"
 
 test("adapter mirrors every tools/*.js and llm/*.js relative dependency into .webagent", async () => {
   const adapterSource = await fs.readFile(path.join(process.cwd(), "src/agent/adapter.ts"), "utf8");
-  assert.ok(adapterSource.includes("../../dist/agent-runtime/tools/**/*.js"));
-  assert.ok(adapterSource.includes('replace(/^.*dist\\/agent-runtime\\/tools\\//, "tools/")'));
-  assert.ok(adapterSource.includes("runtimeToolSources"));
-  assert.ok(adapterSource.includes("../../dist/agent-runtime/llm/**/*.js"));
-  assert.ok(adapterSource.includes("runtimeLlmModuleSources"));
+  assert.ok(adapterSource.includes("../../dist/agent-runtime/**/*.js"));
+  assert.ok(adapterSource.includes("dist\\/agent-runtime\\/"));
+  assert.ok(adapterSource.includes("runtimeModuleSources"));
 });

--- a/tests/embed-runtime-deploy.test.ts
+++ b/tests/embed-runtime-deploy.test.ts
@@ -24,6 +24,12 @@ function adapterDeployPaths(adapterSource: string): Set<string> {
   while ((m = writeRe.exec(adapterSource))) {
     paths.add(m[1]);
   }
+  if (adapterSource.includes("dist/agent-runtime/**/*.js")) {
+    for (const rel of listDistJsFiles(distRuntime)) {
+      paths.add(rel);
+    }
+    return paths;
+  }
   if (adapterSource.includes('dist/agent-runtime/tools/**/*.js')) {
     for (const rel of listDistJsFiles(path.join(distRuntime, "tools"))) {
       paths.add(`tools/${rel}`);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the two Tier 1 code-size simplifications from the `/simplify` review.

## Changes

### `adapter.ts` (~−184 lines)
- Replaced ~70 explicit `?raw` imports and per-file `writeFile` calls with one `import.meta.glob("../../dist/agent-runtime/**/*.js")`.
- `writeRuntimeSources` now loops `runtimeModuleSources` once (package.json + sql.js vendor assets remain explicit).

### `remote-tools.ts` (~−118 lines in `sessionSearchTool`)
- Added shared helpers: `sessionSearchTokenScore`, `sessionSearchSnippet`, `appendSessionSearchHits`, `listRecentJsonFiles`, `runSearchableFromRunJson`.
- Preserves conversation-specific recency snippet behavior (`offsetRecencySnippet: false` for conversations).

### Tests
- `embed-runtime-deploy.test.ts` and `context-compression.test.ts` updated for the unified glob.

## Verification

- `npx tsc -b --noEmit`
- `npm test` — 848 pass, 1 skipped

## Net

**−286 lines** across 4 files.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0c22887-3a41-43aa-a1d7-8f328efcd6be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0c22887-3a41-43aa-a1d7-8f328efcd6be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

