### PR TITLE
fix(runtime): inline MCP env interpolation for Nodebox boot

### DIFF
--- a/src/agent/runtime/mcp-config.ts
+++ b/src/agent/runtime/mcp-config.ts
@@ -1,5 +1,4 @@
 import fs from "node:fs/promises";
-import { interpolateEnvString } from "../../core/mcp/config.js";
 import { MCP_SERVERS_REL, workspaceStatePath } from "./constants.js";
 import { loadMcpSecrets, mcpSecretsToEnv } from "./mcp-secrets.js";
 
@@ -26,6 +25,13 @@ export type McpServerConfig = {
 export type McpServersConfig = Record<string, McpServerConfig>;
 
 const ENV_VAR_PATTERN = /\$\{([^}]+)\}/g;
+
+function interpolateEnvString(text: string, env: Record<string, string>): string {
+  return String(text || "").replace(ENV_VAR_PATTERN, (_, name: string) => {
+    const key = String(name || "").trim();
+    return key && env[key] != null ? String(env[key]) : "";
+  });
+}
 
 export function mcpConfigPath(): string {
   return workspaceStatePath(MCP_SERVERS_REL);

--- a/src/agent/runtime/turn-continuation.ts
+++ b/src/agent/runtime/turn-continuation.ts
@@ -17,7 +17,7 @@ export const MAX_API_DISCOVERY_STALL_CONTINUATIONS = 1;
 export const MAX_PRE_TOOL_PROMISE_CONTINUATIONS = 5;
 export const MAX_CRON_VERIFY_CONTINUATIONS = 1;
 export const MAX_INCOMPLETE_TODO_CONTINUATIONS = 2;
-export const MAX_FIND_SKILLS_DELIVERY_CONTINUATIONS = 2;
+export const MAX_FIND_SKILLS_DELIVERY_CONTINUATIONS = 3;
 
 export const SYNTHETIC_EMPTY_ASSISTANT_CONTENT = "(empty)";
 
@@ -605,27 +605,21 @@ export function looksLikeEmptyResponse(visible: string): boolean {
   return !String(visible || "").trim();
 }
 
-type WebToolExecution = { tool?: string };
-
 /** find-skills ran web discovery but never delivered the ranked pipe table. */
 export function looksLikeFindSkillsDeliveryStall(
   userMessage: string,
   visible: string,
   executedToolsInTurn: boolean,
-  lastExecutions: WebToolExecution[]
+  webDiscoveryCalls: number
 ): boolean {
   if (!executedToolsInTurn) return false;
   if (!/find-skills mode/i.test(String(userMessage || ""))) return false;
-  const webCalls = (lastExecutions || []).filter(
-    (item) => item?.tool === "web_search" || item?.tool === "web_fetch"
-  ).length;
-  if (webCalls < 2) return false;
+  if (webDiscoveryCalls < 2) return false;
   const vis = String(visible || "").trim();
-  if (!vis) return true;
   if (/\|\s*#\s*\|/i.test(vis) && /\|\s*Skill/i.test(vis)) return false;
   const pipes = vis.match(/\|/g)?.length ?? 0;
   if (/top 5 skills/i.test(vis) && pipes >= 6) return false;
-  return true;
+  return webDiscoveryCalls >= 2;
 }
 
 export function looksLikeTruncatedResponse(finishReason: string | null | undefined): boolean {
@@ -817,8 +811,9 @@ export function buildContinuationNudge(
   if (kind === "find_skills_delivery") {
     return (
       "You completed find-skills web_search/web_fetch but have not delivered the final answer. " +
+      "Stop fetching more registry pages. Synthesize from search snippets and any successful fetches you already have. " +
       "Present exactly 5 deduped skills in a markdown pipe table (Skill | Registry | Popularity | Summary | Install/link) " +
-      "ranked by installs, stars, or votes. Do not install — offer install only after the table."
+      "ranked by installs, stars, or votes — note 'metric unavailable' when a registry blocked fetch. Do not install."
     );
   }
   if (kind === "all_tools_rejected") {
@@ -918,11 +913,11 @@ export function shouldContinueFindSkillsDelivery(
   userMessage: string,
   visible: string,
   executedToolsInTurn: boolean,
-  lastExecutions: WebToolExecution[],
+  webDiscoveryCalls: number,
   findSkillsDeliveryContinuations: number
 ): boolean {
   if (findSkillsDeliveryContinuations >= MAX_FIND_SKILLS_DELIVERY_CONTINUATIONS) return false;
-  return looksLikeFindSkillsDeliveryStall(userMessage, visible, executedToolsInTurn, lastExecutions);
+  return looksLikeFindSkillsDeliveryStall(userMessage, visible, executedToolsInTurn, webDiscoveryCalls);
 }
 
 export function shouldContinueSnapshotReadStall(

--- a/src/agent/runtime/turn-continuation.ts
+++ b/src/agent/runtime/turn-continuation.ts
@@ -17,6 +17,7 @@ export const MAX_API_DISCOVERY_STALL_CONTINUATIONS = 1;
 export const MAX_PRE_TOOL_PROMISE_CONTINUATIONS = 5;
 export const MAX_CRON_VERIFY_CONTINUATIONS = 1;
 export const MAX_INCOMPLETE_TODO_CONTINUATIONS = 2;
+export const MAX_FIND_SKILLS_DELIVERY_CONTINUATIONS = 2;
 
 export const SYNTHETIC_EMPTY_ASSISTANT_CONTENT = "(empty)";
 
@@ -604,6 +605,29 @@ export function looksLikeEmptyResponse(visible: string): boolean {
   return !String(visible || "").trim();
 }
 
+type WebToolExecution = { tool?: string };
+
+/** find-skills ran web discovery but never delivered the ranked pipe table. */
+export function looksLikeFindSkillsDeliveryStall(
+  userMessage: string,
+  visible: string,
+  executedToolsInTurn: boolean,
+  lastExecutions: WebToolExecution[]
+): boolean {
+  if (!executedToolsInTurn) return false;
+  if (!/find-skills mode/i.test(String(userMessage || ""))) return false;
+  const webCalls = (lastExecutions || []).filter(
+    (item) => item?.tool === "web_search" || item?.tool === "web_fetch"
+  ).length;
+  if (webCalls < 2) return false;
+  const vis = String(visible || "").trim();
+  if (!vis) return true;
+  if (/\|\s*#\s*\|/i.test(vis) && /\|\s*Skill/i.test(vis)) return false;
+  const pipes = vis.match(/\|/g)?.length ?? 0;
+  if (/top 5 skills/i.test(vis) && pipes >= 6) return false;
+  return true;
+}
+
 export function looksLikeTruncatedResponse(finishReason: string | null | undefined): boolean {
   return String(finishReason || "").trim().toLowerCase() === "length";
 }
@@ -619,7 +643,8 @@ export type ContinuationNudgeKind =
   | "pre_tool_promise"
   | "cron_verify"
   | "incomplete_todos"
-  | "all_tools_rejected";
+  | "all_tools_rejected"
+  | "find_skills_delivery";
 
 export type TodoCompletionStats = {
   total: number;
@@ -789,6 +814,13 @@ export function buildContinuationNudge(
       "then send the user's requested final line."
     );
   }
+  if (kind === "find_skills_delivery") {
+    return (
+      "You completed find-skills web_search/web_fetch but have not delivered the final answer. " +
+      "Present exactly 5 deduped skills in a markdown pipe table (Skill | Registry | Popularity | Summary | Install/link) " +
+      "ranked by installs, stars, or votes. Do not install — offer install only after the table."
+    );
+  }
   if (kind === "all_tools_rejected") {
     const names = extra?.rejectedToolNames;
     const nameList = Array.isArray(names) && names.length
@@ -880,6 +912,17 @@ export function shouldContinuePostToolStall(
 ): boolean {
   if (postToolStallContinuations >= MAX_POST_TOOL_STALL_CONTINUATIONS) return false;
   return looksLikePostToolStall(visible, executedToolsInTurn);
+}
+
+export function shouldContinueFindSkillsDelivery(
+  userMessage: string,
+  visible: string,
+  executedToolsInTurn: boolean,
+  lastExecutions: WebToolExecution[],
+  findSkillsDeliveryContinuations: number
+): boolean {
+  if (findSkillsDeliveryContinuations >= MAX_FIND_SKILLS_DELIVERY_CONTINUATIONS) return false;
+  return looksLikeFindSkillsDeliveryStall(userMessage, visible, executedToolsInTurn, lastExecutions);
 }
 
 export function shouldContinueSnapshotReadStall(

--- a/src/agent/runtime/turn.ts
+++ b/src/agent/runtime/turn.ts
@@ -119,6 +119,7 @@ import {
   shouldContinuePreToolPromiseStall,
   shouldContinueSnapshotReadStall,
   shouldContinueApiDiscoveryStall,
+  shouldContinueFindSkillsDelivery,
   shouldContinueTruncation,
 } from "./turn-continuation.js";
 import { dropTrailingEmptyResponseScaffolding, sanitizeMessagesForLlm } from "./message-sanitizer.js";
@@ -587,6 +588,7 @@ export async function agentTurn(
   let postToolStallContinuations = 0;
   let snapshotReadStallContinuations = 0;
   let apiDiscoveryStallContinuations = 0;
+  let findSkillsDeliveryContinuations = 0;
   let preToolPromiseContinuations = 0;
   let cronVerifyContinuations = 0;
   let incompleteTodoContinuations = 0;
@@ -974,6 +976,25 @@ export async function agentTurn(
           await logDebugEvent("turn_api_discovery_stall_continuation", {
             round,
             count: apiDiscoveryStallContinuations,
+            visiblePreview: String(visible || "").slice(0, 200),
+          });
+          continue;
+        }
+        if (
+          shouldContinueFindSkillsDelivery(
+            originalUserInput,
+            visible,
+            executedToolsInTurn,
+            lastToolExecutions,
+            findSkillsDeliveryContinuations
+          )
+        ) {
+          findSkillsDeliveryContinuations++;
+          continuationRecoveriesFired++;
+          conv.push({ role: "user", content: buildContinuationNudge("find_skills_delivery") });
+          await logDebugEvent("turn_find_skills_delivery_continuation", {
+            round,
+            count: findSkillsDeliveryContinuations,
             visiblePreview: String(visible || "").slice(0, 200),
           });
           continue;

--- a/src/agent/runtime/turn.ts
+++ b/src/agent/runtime/turn.ts
@@ -440,6 +440,18 @@ export async function agentTurn(
     }
   };
 
+  const applyFindSkillsDeliveryLock = async () => {
+    if (findSkillsDeliveryContinuations <= 0) return;
+    if (!/find-skills mode/i.test(originalUserInput)) return;
+    const locked = activeToolNames.filter((n) => n !== "web_search" && n !== "web_fetch");
+    if (locked.length === activeToolNames.length) return;
+    activeToolNames = locked;
+    streamToolsKey = `${activeToolNames.join(",")}::${catalogSchemaFingerprint(buildActiveCatalog(activeToolNames))}`;
+    streamTools = await rebuildStreamTools(activeToolNames);
+    const activeState = turnCtx.services?.activeToolNamesState as { list?: string[] } | undefined;
+    if (activeState) activeState.list = activeToolNames;
+  };
+
   const noteToolUnlocksFromResults = async (
     exec: Array<Record<string, unknown>>,
     calls: Array<{ name?: string; arguments?: unknown }>
@@ -521,6 +533,7 @@ export async function agentTurn(
   let executedToolsInTurn = false;
   let webSearchCountInTurn = 0;
   let webFetchCountInTurn = 0;
+  let webDiscoveryCallsInTurn = 0;
   const researchIntent = isResearchIntent(originalUserInput);
   const successfulToolKeysInTurn = new Set<string>();
   let conv = [...fullMessages];
@@ -614,6 +627,7 @@ export async function agentTurn(
       }
       round++;
       const roundStartedAt = Date.now();
+      await applyFindSkillsDeliveryLock();
       const convCharsBefore = conv.reduce((n, m) => n + String(m?.content || "").length, 0);
       const estTokensBefore = estimateMessagesTokens(conv);
       const midPrune = pruneConversationForMidTurn(conv, cfg);
@@ -985,13 +999,14 @@ export async function agentTurn(
             originalUserInput,
             visible,
             executedToolsInTurn,
-            lastToolExecutions,
+            webDiscoveryCallsInTurn,
             findSkillsDeliveryContinuations
           )
         ) {
           findSkillsDeliveryContinuations++;
           continuationRecoveriesFired++;
           conv.push({ role: "user", content: buildContinuationNudge("find_skills_delivery") });
+          await applyFindSkillsDeliveryLock();
           await logDebugEvent("turn_find_skills_delivery_continuation", {
             round,
             count: findSkillsDeliveryContinuations,
@@ -1190,6 +1205,7 @@ export async function agentTurn(
       for (let i = 0; i < tools.length; i++) {
         const tname = String(tools[i]?.name || "");
         const item = exec[i];
+        if (tname === "web_search" || tname === "web_fetch") webDiscoveryCallsInTurn += 1;
         if (!item?.error) {
           successfulToolKeysInTurn.add(toolExecutionKey(tools[i]));
           if (tname === "web_search") webSearchCountInTurn += 1;
@@ -1290,6 +1306,25 @@ export async function agentTurn(
           role: "user",
           content:
             "Research reminder: your last step was search-only. Run web_fetch on at least two URLs from those results (YouTube channel or video pages first) before concluding.",
+        });
+      }
+      if (
+        shouldContinueFindSkillsDelivery(
+          originalUserInput,
+          "",
+          true,
+          webDiscoveryCallsInTurn,
+          findSkillsDeliveryContinuations
+        )
+      ) {
+        findSkillsDeliveryContinuations++;
+        continuationRecoveriesFired++;
+        conv.push({ role: "user", content: buildContinuationNudge("find_skills_delivery") });
+        await applyFindSkillsDeliveryLock();
+        await logDebugEvent("turn_find_skills_delivery_midturn", {
+          round,
+          count: findSkillsDeliveryContinuations,
+          webDiscoveryCalls: webDiscoveryCallsInTurn,
         });
       }
       if (

--- a/tests/e2e-helpers.ts
+++ b/tests/e2e-helpers.ts
@@ -25,13 +25,13 @@ export function editProfileButton(page: Page, profileName: string) {
 }
 
 export function runningChatInput(page: Page) {
-  return page.getByPlaceholder("Type message (Enter to send, /stop to interrupt)");
+  return page.getByPlaceholder("Type message (Enter to send, @ to reference files)");
 }
 
 /** Matches chat input in idle or running states (placeholder changes). */
 export function anyChatInput(page: Page) {
   return page.locator(
-    'textarea[placeholder="Type message (Enter to send, /stop to interrupt)"], textarea[placeholder="Launch the agent to start chatting"], textarea[placeholder="Press Enter to accept default, or type a name"]'
+    'textarea[placeholder="Type message (Enter to send, @ to reference files)"], textarea[placeholder="Launch the agent to start chatting"], textarea[placeholder="Press Enter to accept default, or type a name"]'
   );
 }
 

--- a/tests/e2e-helpers.ts
+++ b/tests/e2e-helpers.ts
@@ -31,7 +31,7 @@ export function runningChatInput(page: Page) {
 /** Matches chat input in idle or running states (placeholder changes). */
 export function anyChatInput(page: Page) {
   return page.locator(
-    'textarea[placeholder="Type message (Enter to send, /stop to interrupt)"], textarea[placeholder="Launch the agent to start chatting"]'
+    'textarea[placeholder="Type message (Enter to send, /stop to interrupt)"], textarea[placeholder="Launch the agent to start chatting"], textarea[placeholder="Press Enter to accept default, or type a name"]'
   );
 }
 

--- a/tests/turn-continuation.test.ts
+++ b/tests/turn-continuation.test.ts
@@ -595,20 +595,22 @@ test("looksLikePostToolStall nudges plan after offer when user already approved 
 
 test("looksLikeFindSkillsDeliveryStall after web tools without table", () => {
   const user = "The user invoked **find-skills mode** via `/find_skills`.";
-  const execs = [{ tool: "web_search" }, { tool: "web_fetch" }];
-  assert.equal(looksLikeFindSkillsDeliveryStall(user, "", true, execs), true);
+  assert.equal(looksLikeFindSkillsDeliveryStall(user, "", true, 2), true);
   assert.equal(
-    looksLikeFindSkillsDeliveryStall(user, "Still fetching registry pages…", true, execs),
+    looksLikeFindSkillsDeliveryStall(user, "Still fetching registry pages…", true, 3),
+    true
+  );
+  assert.equal(
+    looksLikeFindSkillsDeliveryStall(user, "I'll grab another live registry page.", true, 6),
     true
   );
   const table =
     "## Top 5 skills for python\n\n| # | Skill | Registry | Popularity | Summary | Install / link |\n|---|---|---|---|---|---|";
-  assert.equal(looksLikeFindSkillsDeliveryStall(user, table, true, execs), false);
+  assert.equal(looksLikeFindSkillsDeliveryStall(user, table, true, 6), false);
 });
 
 test("shouldContinueFindSkillsDelivery respects cap", () => {
   const user = "find-skills mode";
-  const execs = [{ tool: "web_search" }, { tool: "web_fetch" }];
-  assert.equal(shouldContinueFindSkillsDelivery(user, "", true, execs, 0), true);
-  assert.equal(shouldContinueFindSkillsDelivery(user, "", true, execs, 2), false);
+  assert.equal(shouldContinueFindSkillsDelivery(user, "", true, 2, 0), true);
+  assert.equal(shouldContinueFindSkillsDelivery(user, "", true, 2, 3), false);
 });

--- a/tests/turn-continuation.test.ts
+++ b/tests/turn-continuation.test.ts
@@ -31,6 +31,8 @@ import {
   MAX_PRE_TOOL_PROMISE_CONTINUATIONS,
   MAX_EMPTY_RESPONSE_CONTINUATIONS,
   MAX_TRUNCATION_CONTINUATIONS,
+  looksLikeFindSkillsDeliveryStall,
+  shouldContinueFindSkillsDelivery,
 } from "../dist/agent-runtime/turn-continuation.js";
 
 const NO_TOOLS: never[] = [];
@@ -589,4 +591,24 @@ test("looksLikePostToolStall nudges plan after offer when user already approved 
     "Want me to try the native sequence?\n\nPlan:\n1. Parse the markdown.\n2. Create parent records.\n\nLet's start with parsing.";
   assert.equal(looksLikePostToolStall(text, true), true);
   assert.equal(shouldSuppressContinuationNudge(text), false);
+});
+
+test("looksLikeFindSkillsDeliveryStall after web tools without table", () => {
+  const user = "The user invoked **find-skills mode** via `/find_skills`.";
+  const execs = [{ tool: "web_search" }, { tool: "web_fetch" }];
+  assert.equal(looksLikeFindSkillsDeliveryStall(user, "", true, execs), true);
+  assert.equal(
+    looksLikeFindSkillsDeliveryStall(user, "Still fetching registry pages…", true, execs),
+    true
+  );
+  const table =
+    "## Top 5 skills for python\n\n| # | Skill | Registry | Popularity | Summary | Install / link |\n|---|---|---|---|---|---|";
+  assert.equal(looksLikeFindSkillsDeliveryStall(user, table, true, execs), false);
+});
+
+test("shouldContinueFindSkillsDelivery respects cap", () => {
+  const user = "find-skills mode";
+  const execs = [{ tool: "web_search" }, { tool: "web_fetch" }];
+  assert.equal(shouldContinueFindSkillsDelivery(user, "", true, execs, 0), true);
+  assert.equal(shouldContinueFindSkillsDelivery(user, "", true, execs, 2), false);
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes agent boot failure in WebContainer and improves find-skills turn completion.

### Boot fix
Inlined `interpolateEnvString` in `mcp-config.ts` so Nodebox bootstrap no longer imports missing `/workspace/core/mcp/config.js`.

### Find-skills continuation (iterative)
- Detect delivery stall using **cumulative** `webDiscoveryCallsInTurn` (includes failed fetches)
- Inject mid-turn synthesis nudge after enough discovery
- Lock out `web_search` / `web_fetch` once delivery nudge fires
- Stronger nudge text: synthesize from snippets instead of fetching more pages

### E2E helpers
Updated chat input placeholder to `@ to reference files` and onboarding placeholder.

## Scenario I retest results (OpenCode, automated Playwright)

| Criterion | Result |
|-----------|--------|
| `web_search` / `web_fetch` executed | ✅ Yes (3–20+ calls depending on run) |
| Ranked pipe table with 5 skills | ❌ Not produced within 10 min |
| `FIND_SKILLS_DONE` token | ❌ Not produced |

**Observed behavior:** After continuation nudge, the model sometimes attempts `web_fetch {}` with empty args or keeps narrating "Let me fetch…" while stuck in `Thinking…`. Registry URLs (skills.sh, skillsmp, cursor marketplace) often return 404/HTML via `web_fetch`, which encourages fetch loops on the free OpenCode tier.

Scenarios E–H from prior manual testing still pass. Scenario I remains flaky on OpenCode without a paid model or mocked registry responses.

## Verification
- `npm test` — 852 passed
- Playwright smoke test — pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54a67cba-5610-4d58-b589-f83eaeedca71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54a67cba-5610-4d58-b589-f83eaeedca71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

