### PR TITLE
test(e2e): Directus skill install and CMS CRUD scenario

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,6 @@ VITE_WEBAGENT_TOOL_LOOP_NO_PROGRESS_BLOCK_AFTER=5
 # WEBAGENT_CORS_PROXY_PORT=8799
 # Used by `npm run test:browser` (loaded via playwright.config.ts from `.env` / `.env.local`)
 TESTING_OPENROUTER_API_KEY=
+# Optional: live Directus skill install + CRUD E2E (`tests/skill-directus-crud.spec.ts`)
+TESTING_DIRECTUS_URL=https://hub.aratech.ae
+TESTING_DIRECTUS_TOKEN=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,5 +39,6 @@ Single-service SPA — only one process needed: `npm run dev` (Vite + embed-runt
 - **Unit tests** (`npm test`) also build the embed runtime first; no extra steps needed.
 - **No linter configured** — there is no ESLint/Prettier/Biome. Type checking (`tsc`) is the primary static analysis tool.
 - **Playwright E2E** (`npm run test:browser`) requires `TESTING_OPENROUTER_API_KEY` in `.env.local` and installed browsers (`npx playwright install chromium`). Skip unless you have an API key.
+- **Directus skill E2E** (`tests/skill-directus-crud.spec.ts`) also needs `TESTING_DIRECTUS_TOKEN` (and optionally `TESTING_DIRECTUS_URL`). Skips when Directus is unreachable via `/api/proxy`.
 - Dev server serves at `http://localhost:5173`. LLM interactions require an API key configured per-profile in the UI (OpenRouter, Ollama, or custom provider).
 - Standard commands are documented in `package.json` scripts and README "Development" section.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -30,10 +30,11 @@ export default defineConfig({
     serviceWorkers: "block",
   },
   webServer: {
-    command: `VITE_WEBAGENT_DEBUG_LOG=1 npm run dev -- --host 127.0.0.1 --port ${port} --strictPort`,
+    /** `npm run dev -- --host` does not reach Vite (concurrently consumes argv); pass flags on the vite child. */
+    command: `VITE_WEBAGENT_DEBUG_LOG=1 npm run build:embed-runtime && npx concurrently -k "npm:watch:embed-runtime" "vite --host 127.0.0.1 --port ${port} --strictPort"`,
     url: baseURL,
     reuseExistingServer: process.env.PW_REUSE_SERVER === "1",
-    timeout: 90_000,
+    timeout: 120_000,
   },
   projects: [
     {

--- a/src/agent/runtime/memory/skill-compat.ts
+++ b/src/agent/runtime/memory/skill-compat.ts
@@ -114,6 +114,7 @@ export function detectPythonLibraries(source: string): string[] {
     libs.add("wikipedia");
   }
   if (/\bpip\s+install\b/.test(text)) libs.add("pip");
+  if (/\bpip\s+install\b[^;\n]*\bdirectus(?:-skill)?\b/i.test(text)) libs.add("directus");
   if (/\bpython3?\s+-m\b/.test(text)) libs.add("python-module-cli");
   return [...libs].sort();
 }
@@ -259,6 +260,11 @@ export function buildWebAgentExecutionAppendix(analysis: SkillCompatAnalysis): s
   }
   if (analysis.python_libraries.includes("wikipedia")) {
     lines.push("| `wikipedia` Python module | Wikipedia REST API via `web_fetch` (`https://en.wikipedia.org/api/rest_v1/…`) |");
+  }
+  if (analysis.python_libraries.includes("directus")) {
+    lines.push(
+      "| Directus Python SDK (`directus`, `directus-skill`, `pip install directus-skill`) | Directus REST/GraphQL via `web_fetch`/`web_post` with `Authorization: Bearer` — **`http-api`**; no Pyodide SDK |"
+    );
   }
   if (/\bwp-json\b|\bWordPress REST\b|\bwp_publisher\b/i.test(analysis.flags.join(" ") + analysis.python_libraries.join(" "))) {
     lines.push("| WordPress REST publisher | `web_post` to `/wp-json/wp/v2/*` with Basic auth — **`http-api`** |");

--- a/src/agent/runtime/memory/skill-import-url.ts
+++ b/src/agent/runtime/memory/skill-import-url.ts
@@ -68,6 +68,10 @@ export function normalizeSkillImportUrl(url: string): string {
     }
     return `https://raw.githubusercontent.com/${tree[1]}/${tree[2]}/${tree[3]}/${path}/SKILL.md`;
   }
+  const repoRoot = raw.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+)\/?$/i);
+  if (repoRoot) {
+    return `https://raw.githubusercontent.com/${repoRoot[1]}/${repoRoot[2]}/main/SKILL.md`;
+  }
   return raw;
 }
 

--- a/tests/e2e-helpers.ts
+++ b/tests/e2e-helpers.ts
@@ -15,6 +15,59 @@ export function testingOpenRouterApiKey(): string {
   return k;
 }
 
+export function testingDirectusUrl(): string {
+  return String(process.env.TESTING_DIRECTUS_URL ?? "https://hub.aratech.ae").trim();
+}
+
+export function testingDirectusToken(): string {
+  let t = String(process.env.TESTING_DIRECTUS_TOKEN ?? "").trim();
+  if (
+    (t.startsWith('"') && t.endsWith('"')) ||
+    (t.startsWith("'") && t.endsWith("'"))
+  ) {
+    t = t.slice(1, -1).trim();
+  }
+  return t;
+}
+
+export function countToolCalls(transcript: string, tool: string): number {
+  const re = new RegExp(`▸\\s*${tool}\\b`, "gi");
+  return (transcript.match(re) || []).length;
+}
+
+/** Probe Directus REST via the dev-server CORS proxy (same path as web_fetch in the browser). */
+export async function directusReachableViaProxy(
+  page: Page,
+  baseUrl: string,
+  token: string
+): Promise<boolean> {
+  const healthUrl = `${baseUrl.replace(/\/$/, "")}/server/health`;
+  return page.evaluate(
+    async ({ url, bearer }) => {
+      try {
+        const res = await fetch("/api/proxy", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            method: "GET",
+            url,
+            headers: { Authorization: `Bearer ${bearer}`, Accept: "application/json" },
+          }),
+        });
+        if (!res.ok) return false;
+        const payload = (await res.json()) as { status?: number; body?: string };
+        const status = Number(payload.status);
+        if (status >= 200 && status < 300) return true;
+        const body = String(payload.body || "");
+        return body.includes('"status"') && body.includes("ok");
+      } catch {
+        return false;
+      }
+    },
+    { url: healthUrl, bearer: token }
+  );
+}
+
 export async function ensureProfilesTab(page: Page) {
   await page.getByRole("button", { name: "Profiles" }).click();
 }

--- a/tests/skill-compat.test.ts
+++ b/tests/skill-compat.test.ts
@@ -60,6 +60,23 @@ test("analyzeSkillCompat marks pdf skill as limited", () => {
   assert.equal(analysis.uses_python, true);
 });
 
+test("buildWebAgentExecutionAppendix maps directus SDK to http-api", () => {
+  const directus = [
+    "---",
+    "name: directus",
+    "---",
+    "",
+    "pip install directus-skill",
+    "from directus import DirectusClient",
+    "",
+    "client = DirectusClient(url=os.environ['DIRECTUS_URL'], token=os.environ['DIRECTUS_API_TOKEN'])",
+  ].join("\n");
+  const appendix = buildWebAgentExecutionAppendix(analyzeSkillCompat(directus));
+  assert.match(appendix, /Directus Python SDK/i);
+  assert.match(appendix, /web_fetch.*web_post|web_post.*web_fetch/i);
+  assert.match(appendix, /http-api/);
+});
+
 test("buildWebAgentExecutionAppendix includes core mappings", () => {
   const appendix = buildWebAgentExecutionAppendix(analyzeSkillCompat(WEB_DESIGN_GUIDELINES));
   assert.match(appendix, /WebFetch.*web_fetch/);

--- a/tests/skill-directus-crud.spec.ts
+++ b/tests/skill-directus-crud.spec.ts
@@ -1,0 +1,163 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { expect, test, type Page } from "@playwright/test";
+import {
+  CHAT_READY_TIMEOUT_MS,
+  clearBrowserStorage,
+  configureOpenRouterApiKey,
+  countToolCalls,
+  createProfile,
+  directusReachableViaProxy,
+  launchDefaultAgent,
+  runningChatInput,
+  testingDirectusToken,
+  testingDirectusUrl,
+  testingOpenRouterApiKey,
+  waitForProfilesLoaded,
+  waitForTurnDrained,
+} from "./e2e-helpers";
+
+const TESTING_OPENROUTER_API_KEY = testingOpenRouterApiKey();
+const TESTING_DIRECTUS_URL = testingDirectusUrl();
+const TESTING_DIRECTUS_TOKEN = testingDirectusToken();
+const LOG_DIR = path.resolve(process.cwd(), "test-results/skill-directus-crud");
+const PROFILE_NAME = "DirectusSkill";
+const SKILL_REPO_URL = "https://github.com/nikola66/directus-skill";
+const CRUD_MARKER = `E2E_BLOG_CRUD_${Date.now()}`;
+
+function requireLiveCredentials() {
+  test.skip(!TESTING_OPENROUTER_API_KEY, "Set TESTING_OPENROUTER_API_KEY to run live Directus skill E2E.");
+  test.skip(!TESTING_DIRECTUS_TOKEN, "Set TESTING_DIRECTUS_TOKEN to run live Directus skill E2E.");
+}
+
+function redact(text: string): string {
+  const token = TESTING_DIRECTUS_TOKEN;
+  let out = String(text || "")
+    .replace(/sk-or-v1-[a-z0-9]+/gi, "sk-or-v1-[redacted]")
+    .replace(/\u001b\[[0-9;?]*[ -/]*[@-~]/g, "");
+  if (token) {
+    out = out.split(token).join("[directus-token-redacted]");
+  }
+  return out;
+}
+
+async function bodyText(page: Page) {
+  return redact(await page.locator("body").innerText({ timeout: 10_000 }));
+}
+
+async function transcriptLength(page: Page): Promise<number> {
+  return await page.evaluate(() => {
+    const w = window as typeof window & { __WEBAGENT_LIVE_TRANSCRIPT__?: unknown[] };
+    return Array.isArray(w.__WEBAGENT_LIVE_TRANSCRIPT__) ? w.__WEBAGENT_LIVE_TRANSCRIPT__.length : 0;
+  });
+}
+
+async function transcriptSince(page: Page, index: number): Promise<string> {
+  return redact(
+    await page.evaluate((from) => {
+      const w = window as typeof window & {
+        __WEBAGENT_LIVE_TRANSCRIPT__?: Array<{ data?: string }>;
+      };
+      return (w.__WEBAGENT_LIVE_TRANSCRIPT__ || [])
+        .slice(from)
+        .map((entry) => String(entry?.data || ""))
+        .join("");
+    }, index)
+  );
+}
+
+async function writeSnapshot(name: string, payload: Record<string, unknown>) {
+  await fs.mkdir(LOG_DIR, { recursive: true });
+  await fs.writeFile(
+    path.join(LOG_DIR, `${Date.now()}-${name}.json`),
+    JSON.stringify(payload, null, 2),
+    "utf8"
+  );
+}
+
+async function sendPromptAndCapture(
+  page: Page,
+  name: string,
+  prompt: string,
+  timeout = 360_000
+) {
+  const before = await bodyText(page);
+  const transcriptStart = await transcriptLength(page);
+  const input = runningChatInput(page);
+  await input.focus();
+  await input.fill(prompt);
+  await input.press("Enter");
+  await waitForTurnDrained(page, timeout);
+  const after = await bodyText(page);
+  const transcript = await transcriptSince(page, transcriptStart);
+  const delta = after.startsWith(before) ? after.slice(before.length).trim() : after;
+  await writeSnapshot(name, { prompt, transcript, delta, afterTail: after.slice(-8000) });
+  return { before, after, delta, transcript };
+}
+
+test.describe.serial("directus skill install and CMS CRUD (live)", () => {
+  requireLiveCredentials();
+  test.setTimeout(900_000);
+
+  test("installs remote skill with pyodide compat then runs blog CRUD via REST", async ({ page }) => {
+    await page.goto("/");
+    await clearBrowserStorage(page);
+    await page.goto("/");
+    await waitForProfilesLoaded(page);
+    await createProfile(page, PROFILE_NAME);
+    await configureOpenRouterApiKey(page, TESTING_OPENROUTER_API_KEY, PROFILE_NAME);
+    await page.getByRole("button", { name: new RegExp(PROFILE_NAME) }).first().click();
+    await launchDefaultAgent(page, "Directus E2E User", true, PROFILE_NAME);
+    await expect(page.getByTestId("chat-input-root")).toHaveAttribute(
+      "data-agent-runtime-status",
+      "running",
+      { timeout: CHAT_READY_TIMEOUT_MS }
+    );
+
+    const reachable = await directusReachableViaProxy(page, TESTING_DIRECTUS_URL, TESTING_DIRECTUS_TOKEN);
+    test.skip(
+      !reachable,
+      `Directus at ${TESTING_DIRECTUS_URL} is not reachable via /api/proxy (Cloudflare or network).`
+    );
+
+    const install = await sendPromptAndCapture(
+      page,
+      "01-skill-install",
+      [
+        `Download, install, and adapt this skill for Web Agent / Pyodide compatibility: ${SKILL_REPO_URL}`,
+        "Use skill_manage import_url or skill_bulk_save — do not create a new skill from scratch.",
+        "After saving, call skill_view on the installed skill and skill_view imported-skill-compat.",
+        "Adapt the procedure so CMS work uses web_fetch/web_post with Bearer auth (http-api), not pip install directus-skill or from directus import.",
+        "When the skill is installed and you have confirmed the compat mapping, reply exactly DIRECTUS_SKILL_READY_TOKEN.",
+      ].join(" "),
+      420_000
+    );
+
+    expect(install.transcript).toMatch(/▸\s*skill_(manage|bulk_save)/i);
+    expect(install.transcript).toMatch(/▸\s*skill_view/i);
+    expect(install.delta).toMatch(/DIRECTUS_SKILL_READY_TOKEN/);
+
+    const crud = await sendPromptAndCapture(
+      page,
+      "02-directus-crud",
+      [
+        `Directus URL: ${TESTING_DIRECTUS_URL}`,
+        `Directus Token: ${TESTING_DIRECTUS_TOKEN}`,
+        "Using the installed directus skill and skill_view http-api, run full CRUD on one blog/article collection:",
+        "1) Discover collections and pick the blog posts (or articles) collection.",
+        `2) CREATE a draft post titled "${CRUD_MARKER}" with minimal required fields.`,
+        `3) UPDATE that record (e.g. append _UPDATED to title or change status).`,
+        "4) DELETE the record (soft or hard delete).",
+        "Use web_fetch/web_post with Authorization Bearer — not run_python with the directus SDK.",
+        "When create, update, and delete all succeeded, reply exactly DIRECTUS_CRUD_OK_TOKEN.",
+      ].join(" "),
+      480_000
+    );
+
+    const httpTools = countToolCalls(crud.transcript, "web_post") + countToolCalls(crud.transcript, "web_fetch");
+    expect(httpTools, "expected REST calls via web_fetch/web_post").toBeGreaterThanOrEqual(2);
+    expect(crud.transcript).not.toMatch(/ModuleNotFoundError:\s*No module named ['"]directus['"]/i);
+    expect(crud.transcript).not.toMatch(/✗\s*run_python[^\n]*directus/i);
+    expect(crud.delta).toMatch(/DIRECTUS_CRUD_OK_TOKEN/);
+  });
+});

--- a/tests/skill-import-url.test.ts
+++ b/tests/skill-import-url.test.ts
@@ -29,6 +29,17 @@ test("normalizeSkillImportUrl converts github tree dir to raw SKILL.md", () => {
   );
 });
 
+test("normalizeSkillImportUrl converts bare github repo root to main/SKILL.md", () => {
+  assert.equal(
+    normalizeSkillImportUrl("https://github.com/nikola66/directus-skill"),
+    "https://raw.githubusercontent.com/nikola66/directus-skill/main/SKILL.md"
+  );
+  assert.equal(
+    normalizeSkillImportUrl("https://github.com/nikola66/directus-skill/"),
+    "https://raw.githubusercontent.com/nikola66/directus-skill/main/SKILL.md"
+  );
+});
+
 test("resolveSkillImportUrlFromPage extracts github tree from skillsmp HTML", () => {
   const html = `
     <a href="https://github.com/LaWebcapsule/d9-skills/tree/main/skills/d9-fork-setup">repo</a>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a live Playwright E2E that exercises a realistic “complicated skill” workflow without introducing a test-only skill:

1. **Install & adapt** [nikola66/directus-skill](https://github.com/nikola66/directus-skill) for Web Agent / Pyodide (REST via `web_fetch`/`web_post`, not `pip install directus-skill`).
2. **CRUD** on a blog/article collection against the configured Directus instance (create → update → delete).

## Generic fixes (found while wiring the test)

- **Skill import:** `https://github.com/owner/repo` (no `/tree/…`) now normalizes to `raw.githubusercontent.com/.../main/SKILL.md`.
- **Skill compat:** auto-appended execution appendix maps Directus Python SDK / `pip install directus-skill` → `http-api` + `web_fetch`/`web_post`.
- **Playwright webServer:** Vite `--host 127.0.0.1` is passed on the `vite` child process (`npm run dev -- --host` never reached Vite through `concurrently`).

## How to run

```bash
# .env.local
TESTING_OPENROUTER_API_KEY=sk-or-...
TESTING_DIRECTUS_URL=https://hub.aratech.ae   # optional; this is the default
TESTING_DIRECTUS_TOKEN=...

npx playwright install chromium
npm run test:browser -- tests/skill-directus-crud.spec.ts
```

The spec **skips** when credentials are missing, or when Directus is unreachable via `/api/proxy` (common behind Cloudflare from CI/datacenter IPs).

## Verification

- `npm test` (unit) — pass
- `npx tsc -b --noEmit` — pass
- `skill-directus-crud.spec.ts` — skipped in cloud agent (no `TESTING_OPENROUTER_API_KEY`; Directus returns Cloudflare 403 from this network)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-918e205c-b33c-4f29-b28c-1de5413842d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-918e205c-b33c-4f29-b28c-1de5413842d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

