### PR TITLE
feat: harden file-type handling + enforce tool I/O invariants (v0.0.69)

### DIFF
--- a/docs/code-review-2026-05-29.md
+++ b/docs/code-review-2026-05-29.md
@@ -1,0 +1,51 @@
+# Web-Agent Code Review — 2026-05-29
+
+Reviewer: automated comprehensive pass (Opus 4.8). Scope: full `src/` tree (~49k LOC, 130+ modules), test suite, and type-check.
+
+## Verification baseline
+
+| Check | Result |
+|-------|--------|
+| `npm test` (node suite) | **871 pass, 0 fail, 1 skip** |
+| Skipped test | `composio-catalog-live` — requires `API_KEY`, expected |
+| `tsc -b` | clean, 0 type errors |
+| Playwright `*.spec.ts` | not run — need live API keys + browser (slow/flaky) |
+
+## Defect found and fixed
+
+**`estimateMessageTokens` undercounted non-string message content.**
+`src/agent/runtime/llm/streaming.ts`
+
+- Before: `estimateTokens(msg.content || "")`. When `content` is an **array** of multimodal parts (text + image), `String(content)` → `"[object Object]"` → ~4 tokens. `tool_calls` payloads were ignored entirely (content is `null` on those messages).
+- Impact: this estimate drives `context-compression.ts` threshold decisions (`maybeCompactHistory`, `compactMessages`, `tailStartIndex`). Undercounting suppresses compaction **exactly when messages are largest** (images, big tool results) → risk of context overflow, dropped history, slower/more-expensive turns.
+- Fix: stringify non-string content (counts text + base64 image length) and add `tool_calls` token cost. Mirrors existing `estimateToolSchemaTokens`.
+- Regression test added: `tests/streaming-sanitize.test.ts` → "estimateMessageTokens counts array content and tool_calls".
+- This is both a correctness fix and a **speed/cost win**: accurate compaction → smaller payloads to the LLM, fewer overflow failures.
+
+## Subsystem review — findings
+
+### Tool execution (`tools/registry.ts`, `runTools`)
+Strong. Read-only safe tools batch concurrently with `MAX_PARALLEL_TOOLS` cap (6); write/unsafe tools stay serial. Dedup of duplicate emissions (native `tool_calls` + `<<<TOOL>>>` markers) via serialized key set. No changes recommended.
+
+### Streaming parser (`llm/streaming.ts`, `createToolAwareStreamWriter`)
+Correct incremental design: buffer is sliced down each `push`, partial hidden-marker prefixes retained across chunks (`longestToolPrefixSuffix`), no unbounded `indexOf` over a growing buffer (no O(n²)). Per-message regexes (`stripPseudoToolCallLines`) compile once per assistant message, not per chunk. Intent regexes are module-level constants.
+
+### Context compaction (`context-compression.ts`)
+`estimateMessagesTokens` called a constant number of times per compaction (before/after), not in a tight loop. Now fed accurate estimates by the fix above.
+
+### UI / React (`ui/components/*`, zustand stores)
+Well-architected. All store reads are **atomic selectors** (`s => s.field`) — no new-object-per-render subscriptions, so no spurious re-renders. `Terminal` consumes the high-frequency output stream via imperative `useRuntimeStore.subscribe`, deliberately bypassing React render churn. `ChatInput`/`StatusBar` use `useMemo`/`useCallback` on derived data.
+
+### Async safety (whole tree)
+No floating/unawaited promises found. `JSON.parse` callsites are consistently wrapped in `try` (or feed `safeParse`-style helpers). No `parseInt` missing radix. No global-regex `lastIndex` reuse bugs.
+
+## Optional improvements (NOT applied — would churn clean, working, tested code)
+
+Listed for the maintainer to decide; each carries regression risk against existing tests/behavior:
+
+1. **Parallelize `listLiveWorkspaceFiles` walk** (`core/workspace.ts:462`) — serial `stat` per entry. `Promise.all` per directory would speed the file-panel refresh, but reorders `results` and stresses nodebox FS concurrency; would risk `workspace-layout-parity` tests. Only worth it if the file panel is measurably slow on large workspaces.
+2. **`estimateTokens` heuristic** — `length / 4` is a rough proxy; fine for thresholds, not for hard budget caps. Leave unless billing-accurate counts are needed.
+
+## Conclusion
+
+Mature, high-quality, well-tested codebase. One real defect found and fixed (with a regression test); type-check and full node suite green. No systemic bug or perf classes detected. Remaining suggestions are optional and risk-noted rather than blindly applied — preserving working behavior over speculative churn.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-agent",
   "private": true,
-  "version": "0.0.68",
+  "version": "0.0.69",
   "type": "module",
   "scripts": {
     "build:embed-runtime": "node scripts/build-embed-runtime.mjs",

--- a/src/agent/runtime/llm/streaming.ts
+++ b/src/agent/runtime/llm/streaming.ts
@@ -187,8 +187,28 @@ export function estimateTokens(text) {
   return Math.max(1, Math.ceil(String(text).length / 4));
 }
 
+function stringifyForEstimate(value) {
+  if (value == null) return "";
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return "";
+  }
+}
+
 export function estimateMessageTokens(msg) {
-  return 4 + estimateTokens(msg?.role || "") + estimateTokens(msg?.content || "");
+  // Content may be a string, an array of multimodal parts, or null with the
+  // payload carried in tool_calls. Stringify non-string shapes so array/tool
+  // content (including base64 image data) is counted instead of collapsing to
+  // "[object Object]" — undercounting here would suppress context compression
+  // exactly when messages are largest.
+  return (
+    4 +
+    estimateTokens(msg?.role || "") +
+    estimateTokens(stringifyForEstimate(msg?.content)) +
+    (msg?.tool_calls ? estimateTokens(stringifyForEstimate(msg.tool_calls)) : 0)
+  );
 }
 
 export function estimateMessagesTokens(messages) {

--- a/src/agent/runtime/memory/skills.ts
+++ b/src/agent/runtime/memory/skills.ts
@@ -1056,6 +1056,15 @@ export async function manageSkill(args: Record<string, unknown> = {}) {
   if (action === "write_file") {
     await assertSkillWritable(record, "write_file");
     const filePath = String(args.file_path || (contentName ? SKILL_FILE_NAME : "")).trim();
+    // Guard against creating an empty support file (the `content` arg was
+    // omitted). Otherwise a later read finds it blank and the work is silently
+    // lost — exactly how an empty references/*.md slipped in.
+    if (!content.trim()) {
+      throw new Error(
+        `skill_manage write_file: \`content\` is required and was empty for "${filePath || "(no file_path)"}". ` +
+          "Pass the full file body in `content`."
+      );
+    }
     return writeManagedSkillFile(record, filePath, content, action);
   }
 

--- a/src/agent/runtime/tools/builtins/apply_patch.ts
+++ b/src/agent/runtime/tools/builtins/apply_patch.ts
@@ -6,5 +6,15 @@ export default defineTool({
   run: applyPatchTool,
   emoji: "🩹",
   description: "Unified patch blocks (`*** Begin Patch`). For single hunk use `edit_file`; for many inline replacements use `multi_edit`. Prefer targets under `projects/<slug>/` or `work/<slug>/`.",
-  inputSchema: { type: "object", properties: {}, additionalProperties: true },
+  inputSchema: {
+    type: "object",
+    properties: {
+      patch: {
+        type: "string",
+        description: "Unified patch text bounded by `*** Begin Patch` / `*** End Patch`.",
+      },
+    },
+    required: ["patch"],
+    additionalProperties: true,
+  },
 });

--- a/src/agent/runtime/tools/builtins/artifact_present.ts
+++ b/src/agent/runtime/tools/builtins/artifact_present.ts
@@ -6,5 +6,18 @@ export default defineTool({
   run: artifactPresentTool,
   emoji: "🪄",
   description: "Present a deliverable to the browser host (View / Download). Call as soon as a visual is ready when the user asked to see it. Inline: `title`, `filename` (.md), and `markdown` body — use for reports and remote images (`![alt](https://…)`). File: `title` and workspace-relative `path` for images, audio, video, PDF, DOCX, PPTX, markdown, or mermaid (.mmd). Provide exactly one of `markdown` or `path`.",
-  inputSchema: { type: "object", properties: {}, additionalProperties: true },
+  inputSchema: {
+    type: "object",
+    properties: {
+      title: { type: "string", description: "Deliverable title shown to the user." },
+      path: {
+        type: "string",
+        description: "Workspace-relative file (image/audio/video/PDF/DOCX/PPTX/markdown/.mmd). Provide this OR `markdown`.",
+      },
+      markdown: { type: "string", description: "Inline markdown body. Provide this OR `path`." },
+      filename: { type: "string", description: "Filename for inline markdown (.md). Default artifact.md." },
+      kind: { type: "string", description: "Optional artifact kind hint." },
+    },
+    additionalProperties: true,
+  },
 });

--- a/src/agent/runtime/tools/builtins/cron_register.ts
+++ b/src/agent/runtime/tools/builtins/cron_register.ts
@@ -7,5 +7,21 @@ export default defineTool({
   run: cronRegisterTool,
   emoji: "⏱️",
   description: CRON_REGISTER_TOOL_DESCRIPTION,
-  inputSchema: { type: "object", properties: {}, additionalProperties: true },
+  inputSchema: {
+    type: "object",
+    properties: {
+      action: { type: "string", enum: ["register", "remove"], description: "register (default) or remove." },
+      id: { type: "string", description: "Job id — required for `remove`." },
+      name: { type: "string", description: "Human label for the job." },
+      everyMinutes: { type: "number", description: "Heartbeat interval in minutes." },
+      tool: { type: "string", description: "Single tool name to run (or use `steps`)." },
+      arguments: { type: "object", additionalProperties: true, description: "Arguments for `tool`." },
+      steps: {
+        type: "array",
+        description: "Multi-step job; each item { tool, arguments }.",
+        items: { type: "object", additionalProperties: true },
+      },
+    },
+    additionalProperties: true,
+  },
 });

--- a/src/agent/runtime/tools/builtins/edit_file.ts
+++ b/src/agent/runtime/tools/builtins/edit_file.ts
@@ -6,5 +6,18 @@ export default defineTool({
   run: editFileTool,
   emoji: "🛠️",
   description: "Single find/replace hunk or full replace via `new_content`. For many hunks use `multi_edit`; for patch blocks use `apply_patch`. New deliverables under `projects/<slug>/` or `work/<slug>/`.",
-  inputSchema: { type: "object", properties: {}, additionalProperties: true },
+  inputSchema: {
+    type: "object",
+    properties: {
+      path: { type: "string", description: "Workspace-relative file to edit." },
+      find: { type: "string", description: "Exact text to replace (alias: old). Omit for a full-file replace." },
+      replace: { type: "string", description: "Replacement text (alias: new)." },
+      new_content: {
+        type: "string",
+        description: "Full new file contents (aliases: content, text) when not using find/replace.",
+      },
+    },
+    required: ["path"],
+    additionalProperties: true,
+  },
 });

--- a/src/agent/runtime/tools/builtins/memory_recall.ts
+++ b/src/agent/runtime/tools/builtins/memory_recall.ts
@@ -6,5 +6,13 @@ export default defineTool({
   run: memoryRecallTool,
   emoji: "💭",
   description: "Recall a single saved memory fact by its exact `key`. Use `memory_search` instead when you only have a topic or substring.",
-  inputSchema: { type: "object", properties: {}, additionalProperties: true },
+  inputSchema: {
+    type: "object",
+    properties: {
+      key: { type: "string", description: "Exact key of the saved fact. Use memory_search for a topic/substring." },
+      limit: { type: "number", description: "Max rows (default 20)." },
+    },
+    required: ["key"],
+    additionalProperties: true,
+  },
 });

--- a/src/agent/runtime/tools/builtins/memory_search.ts
+++ b/src/agent/runtime/tools/builtins/memory_search.ts
@@ -9,5 +9,13 @@ export default defineTool({
     "Substring-search saved memory facts by `query`. Returns matching key/value rows. " +
     "Use when you need durable facts from prior sessions. Use `session_search` for past chat transcripts; " +
     "use `memory_recall` when you already know the exact key.",
-  inputSchema: { type: "object", properties: {}, additionalProperties: true },
+  inputSchema: {
+    type: "object",
+    properties: {
+      query: { type: "string", description: "Topic or substring to match across saved facts." },
+      limit: { type: "number", description: "Max results (default 30, max 1000)." },
+    },
+    required: ["query"],
+    additionalProperties: true,
+  },
 });

--- a/src/agent/runtime/tools/builtins/multi_edit.ts
+++ b/src/agent/runtime/tools/builtins/multi_edit.ts
@@ -6,5 +6,17 @@ export default defineTool({
   run: multiEditTool,
   emoji: "🛠️",
   description: "Multiple find/replace edits in one file. For a single hunk use `edit_file`; for unified patch blocks use `apply_patch`. Anchor new work under `projects/<slug>/` or `work/<slug>/`.",
-  inputSchema: { type: "object", properties: {}, additionalProperties: true },
+  inputSchema: {
+    type: "object",
+    properties: {
+      path: { type: "string", description: "Workspace-relative file to edit." },
+      edits: {
+        type: "array",
+        description: "Edits applied in order. Each item: { find/old, replace/new }.",
+        items: { type: "object", additionalProperties: true },
+      },
+    },
+    required: ["path", "edits"],
+    additionalProperties: true,
+  },
 });

--- a/src/agent/runtime/tools/builtins/todo_write.ts
+++ b/src/agent/runtime/tools/builtins/todo_write.ts
@@ -5,6 +5,31 @@ export default defineTool({
   name: "todo_write",
   run: todoWriteTool,
   emoji: "✅",
-  description: "Create or update checklist-style todos.",
-  inputSchema: { type: "object", properties: {}, additionalProperties: true },
+  description:
+    "Create or update checklist-style todos. Pass `todos`: an array of `{ id, text, status }` " +
+    "(status one of pending|in_progress|done). `items`/`tasks` are accepted aliases for `todos`, " +
+    "and `text`/`title`/`task` for the label. Replaces the full list each call.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      todos: {
+        type: "array",
+        description: "Full todo list (replaces previous). Each item: { id, text, status }.",
+        items: {
+          type: "object",
+          properties: {
+            id: { type: "string", description: "Stable id (string or number)." },
+            text: { type: "string", description: "Todo label. Aliases: title, task, content." },
+            status: {
+              type: "string",
+              enum: ["pending", "in_progress", "done"],
+              description: "Defaults to pending.",
+            },
+          },
+          required: ["text"],
+        },
+      },
+    },
+    additionalProperties: true,
+  },
 });

--- a/src/agent/runtime/tools/builtins/youtube_transcribe.ts
+++ b/src/agent/runtime/tools/builtins/youtube_transcribe.ts
@@ -6,5 +6,13 @@ export default defineTool({
   run: youtubeTranscribeTool,
   emoji: "📹",
   description: "Fetch and return the full transcript/captions of a YouTube video by URL. Returns text with timestamps. Useful for understanding video content without watching.",
-  inputSchema: { type: "object", properties: {}, additionalProperties: true },
+  inputSchema: {
+    type: "object",
+    properties: {
+      url: { type: "string", description: "YouTube video URL or id." },
+      language: { type: "string", description: "Preferred caption language code (default en)." },
+    },
+    required: ["url"],
+    additionalProperties: true,
+  },
 });

--- a/src/agent/runtime/tools/error-classifier.ts
+++ b/src/agent/runtime/tools/error-classifier.ts
@@ -179,6 +179,29 @@ function classifyFromMessage(message: string, statusHint: number | null): Omit<C
     };
   }
 
+  // Extracting archives via run_python in Pyodide: zipfile/tarfile + os.listdir
+  // return JsProxy objects and binary reads fail. Redirect to the dedicated tool
+  // before the generic JsProxy/HTTP branch below claims this is an HTTP error.
+  if (
+    /\b(?:zipfile|tarfile)\b/i.test(message) ||
+    /shutil\.unpack_archive|\.extractall\b/i.test(message) ||
+    (/JsProxy/i.test(message) && /\b(?:listdir|extractall|namelist)\b/i.test(message))
+  ) {
+    reason = "format_error";
+    retryable = false;
+    shouldFallback = true;
+    error_code = "pyodide_archive_misuse";
+    return {
+      reason,
+      retryable,
+      shouldCompress,
+      shouldFallback,
+      error_code,
+      hintBase:
+        "Don't extract archives with run_python in Pyodide (zipfile/tarfile + os.listdir return JsProxy objects, binary reads fail). Use the `extract_archive` tool (ZIP/TAR/TGZ) then browse_workspace the output; `archive_list` inspects without extracting. Creating a zip with stdlib zipfile is fine — only extraction needs the tool.",
+    };
+  }
+
   if (
     /JsProxy.*not iterable|pyodide\.ffi\.JsProxy|urllib\.request\.urlopen/i.test(message)
   ) {

--- a/src/agent/runtime/tools/filesystem/read.ts
+++ b/src/agent/runtime/tools/filesystem/read.ts
@@ -39,6 +39,48 @@ async function snapshotJsonPeers(absFilePath, limit = 44) {
     .slice(0, limit);
 }
 
+/**
+ * Map a workspace path's extension to the dedicated tool for that binary/media
+ * type. read_file decodes utf8, which corrupts these formats and returns
+ * mojibake (the agent then "succeeds" on garbage). Short-circuit with a
+ * recovery message naming the right tool instead. Returns null for
+ * text-readable files. Pure + exported for unit testing.
+ */
+const BINARY_READ_TOOL_HINTS: Array<{ re: RegExp; hint: string }> = [
+  {
+    re: /\.(?:zip|tar|tgz|tar\.gz)$/i,
+    hint: "extract it with `extract_archive` (ZIP/TAR/TGZ) or inspect entries with `archive_list` — read_file cannot decode archive bytes, and Nodebox has no POSIX `unzip`/`tar`. Do not run_python zipfile to EXTRACT (os.listdir/binary reads raise JsProxy errors in Pyodide)",
+  },
+  { re: /\.pdf$/i, hint: "extract text with `pdf_extract` — read_file returns raw PDF bytes, not text" },
+  {
+    re: /\.docx$/i,
+    hint: "extract text with `docx_extract` — a .docx is a zipped XML bundle, not plain text",
+  },
+  {
+    re: /\.(?:png|jpe?g|gif|webp|bmp|heic|heif|tiff?|ico)$/i,
+    hint: "analyze it with `vision_analyze`, or get dimensions/metadata with `image_info` — read_file cannot decode image bytes",
+  },
+  {
+    re: /\.(?:mp3|wav|m4a|aac|ogg|flac|opus)$/i,
+    hint: "transcribe/analyze it with `audio_analyze` — read_file cannot decode audio bytes",
+  },
+  {
+    re: /\.(?:mp4|mov|webm|mkv|avi)$/i,
+    hint: "extract audio then `audio_analyze`; for a YouTube URL use `youtube_transcribe` — read_file cannot decode video bytes",
+  },
+];
+
+export function binaryReadRecovery(rel: string): string | null {
+  const path = String(rel || "").trim().toLowerCase();
+  if (!path) return null;
+  for (const { re, hint } of BINARY_READ_TOOL_HINTS) {
+    if (re.test(path)) {
+      return `'${rel}' is a binary file — ${hint}. See skill_view \`browser-runtime-map\` for the full tool picker.`;
+    }
+  }
+  return null;
+}
+
 export function getReadFileMaxChars() {
   const n = Number(process.env.WEBAGENT_READ_FILE_MAX_CHARS);
   if (Number.isFinite(n) && n >= 1000) return Math.floor(n);
@@ -115,6 +157,8 @@ export async function readFileTool(args = {}, ctx) {
   if (isMemoryRunArchivePath(normalized)) {
     throw new Error(memoryRunArchiveBlockedMessage(normalized));
   }
+  const binaryHint = binaryReadRecovery(normalized);
+  if (binaryHint) throw new Error(binaryHint);
 
   async function innerReadFile() {
     const abs = resolveWorkspacePath(ctx, rel);

--- a/src/agent/runtime/tools/python-tools.ts
+++ b/src/agent/runtime/tools/python-tools.ts
@@ -83,6 +83,7 @@ export async function runPythonTool(args: Record<string, unknown>, ctx: any) {
     exit_code?: number;
     files_written?: string[];
     pyodide_version?: string;
+    sync_note?: string;
   };
   if (!raw.ok) {
     throw new Error(String(raw.error || "run_python failed"));
@@ -92,6 +93,7 @@ export async function runPythonTool(args: Record<string, unknown>, ctx: any) {
     stderr: String(raw.stderr ?? ""),
     exit_code: Number(raw.exit_code ?? 0),
     files_written: Array.isArray(raw.files_written) ? raw.files_written : [],
+    ...(raw.sync_note ? { sync_note: raw.sync_note } : {}),
     ...(raw.pyodide_version ? { pyodide_version: raw.pyodide_version } : {}),
     ...(pre.autoPackages.length ? { auto_packages: pre.autoPackages } : {}),
     ...(pre.micropipPackages.length ? { micropip_packages: pre.micropipPackages } : {}),

--- a/src/agent/runtime/tools/remote-tools.ts
+++ b/src/agent/runtime/tools/remote-tools.ts
@@ -628,7 +628,19 @@ export function summarizeHttpErrorBody(data: unknown, status: number): string {
 export function graphqlSchemaRecoveryHint(data: unknown, status: number): string | undefined {
   if (status !== 400 && status !== 422) return undefined;
   const text = JSON.stringify(data || "");
-  if (!/graphql|Cannot query field/i.test(text)) return undefined;
+  const isGraphql = /graphql|Cannot query field|_input\b|of required type|was not provided/i.test(text);
+  if (!isGraphql) return undefined;
+  // Relation input-shape error: trying to link an existing related record but
+  // the create-input demands all its non-null fields. This is the loop that
+  // stalled a blog publish across ~8 introspection calls.
+  if (/_input\b|of required type|was not provided|non[- ]?null/i.test(text)) {
+    return (
+      "GraphQL mutation input-shape error. To LINK an existing related record (author, category, etc.), pass the relation as a nested object with only its id — e.g. `author: { id: \"1\" }` — not a bare id, and not the full create object with all fields. " +
+      "If a `create_*_input` still demands every non-null field, the relation field actually accepts the lighter input that only needs `id`. " +
+      "Put large or HTML field values in GraphQL `variables` (web_post `json: { query, variables }`) rather than inlining them in the query string, to avoid JSON-escaping corruption. " +
+      "See skill_view on the relevant imported skill and **`http-api`** for the exact shape."
+    );
+  }
   return (
     "GraphQL root fields must match that API's schema — do not assume generic names. " +
     "Call skill_view on the relevant imported skill (and **`http-api`**) for discovery endpoints and query shape, " +
@@ -1636,8 +1648,13 @@ function normalizeTodoStatus(status) {
 
 function normalizeTodoItem(item, index) {
   const src = item && typeof item === "object" && !Array.isArray(item) ? item : {};
-  const content = String(src.content || "").trim() || `Todo ${index + 1}`;
-  const id = String(src.id || `todo-${Date.now()}-${index + 1}`).trim() || `todo-${Date.now()}-${index + 1}`;
+  // Accept the common label aliases models reach for (text/title/task/label),
+  // not just `content` — otherwise every todo silently becomes "Todo N".
+  const content =
+    String(src.content ?? src.text ?? src.title ?? src.task ?? src.label ?? src.name ?? "").trim() ||
+    `Todo ${index + 1}`;
+  const fallbackId = `todo-${Date.now()}-${index + 1}`;
+  const id = String(src.id ?? fallbackId).trim() || fallbackId;
   return { id, content, status: normalizeTodoStatus(src.status) };
 }
 
@@ -1764,17 +1781,37 @@ export async function skillManageTool(args: ToolArgs = {}, ctx) {
 export async function todoWriteTool(payload: ToolArgs | unknown[] = {}, _ctx) {
   const todosPath = workspaceStatePath(".webagent/todos.json");
   let rawTodos: unknown[] = [];
+  let sawArrayKey = false;
   if (Array.isArray(payload)) rawTodos = payload;
-  else if (Array.isArray((payload as ToolArgs).todos)) rawTodos = (payload as ToolArgs).todos as unknown[];
-  else if (payload && typeof payload === "object" && !Array.isArray(payload)) {
+  else if (payload && typeof payload === "object") {
     const p = payload as ToolArgs;
-    const looksLikeSingleTodo = ["id", "content", "status"].some((key) =>
-      Object.prototype.hasOwnProperty.call(p, key)
+    // Accept any of the array keys models commonly use, not just `todos`.
+    const arrayKey = ["todos", "items", "tasks", "list", "steps", "checklist"].find((key) =>
+      Array.isArray(p[key])
     );
-    if (looksLikeSingleTodo) rawTodos = [p];
+    if (arrayKey) {
+      rawTodos = p[arrayKey] as unknown[];
+      sawArrayKey = true;
+    } else {
+      const looksLikeSingleTodo = ["id", "content", "text", "title", "task", "status"].some((key) =>
+        Object.prototype.hasOwnProperty.call(p, key)
+      );
+      if (looksLikeSingleTodo) rawTodos = [p];
+    }
+  }
+  // A non-empty array that yielded nothing usable means the caller's item shape
+  // is wrong — surface it instead of silently returning count:0 (which reads as
+  // success and makes the model abandon planning).
+  if (sawArrayKey && rawTodos.length === 0) {
+    throw new Error(
+      "todo_write received an empty todo list. Pass `todos` as an array of objects like " +
+        '`{ "todos": [{ "id": "1", "text": "step", "status": "in_progress" }] }`.'
+    );
   }
   const todos = rawTodos.map((todo, index) => normalizeTodoItem(todo, index));
-  await fs.mkdir(getWorkspaceRoot(), { recursive: true });
+  // mkdir the `.webagent` parent, not just the workspace root — otherwise the
+  // write ENOENTs on a fresh workspace where `.webagent/` does not exist yet.
+  await fs.mkdir(nodePath.dirname(todosPath), { recursive: true });
   await fs.writeFile(todosPath, JSON.stringify(todos, null, 2), "utf8");
   return { ok: true, count: todos.length };
 }

--- a/src/agent/runtime/tools/tool-policy-config.ts
+++ b/src/agent/runtime/tools/tool-policy-config.ts
@@ -34,7 +34,7 @@ export const TOOL_GROUPS: Record<string, readonly string[]> = {
   filesystem_mutate: ["make_dir", "delete_file", "move_file", "file_diff"],
   memory: ["memory_save", "memory_recall", "memory_search", "memory_forget"],
   session: ["session_memory_append", "session_memory_list", "session_search"],
-  skills: ["skill_manage", "skill_bulk_save"],
+  skills: ["skill_manage", "skill_bulk_save", "capability_list"],
   wiki: ["wiki_setup", "wiki_sync", "wiki_search"],
   composio: ["composio_connect", "composio_status", "composio_action"],
   cron: ["cron_register", "cron_list"],

--- a/src/agent/runtime/tools/tool-search-tools.ts
+++ b/src/agent/runtime/tools/tool-search-tools.ts
@@ -1,3 +1,5 @@
+import { toolsInDeferredGroups } from "./tool-policy-config.js";
+
 const HIDDEN_BROWSE_ALIASES = new Set(["list_dir", "find_files", "tree"]);
 
 export function isHiddenBrowseAlias(name: string): boolean {
@@ -7,6 +9,12 @@ export function isHiddenBrowseAlias(name: string): boolean {
 export function isDeferredCatalogTool(name: string, meta: { llmVisible?: boolean } | null | undefined): boolean {
   if (String(name || "").startsWith("mcp_")) return false;
   if (meta?.llmVisible === false) return true;
+  // Group-deferred tools (archives/documents/multimodal/wiki/cron/delivery/…)
+  // are NOT marked llmVisible:false — they're held back by DEFERRED_TOOL_GROUPS
+  // and the active-tool filter. They must still be discoverable here, or
+  // `tool_search("extract_archive")` returns nothing for a real, unlockable
+  // tool (the exact failure that stranded a zip extraction).
+  if (toolsInDeferredGroups().has(String(name || ""))) return true;
   return false;
 }
 

--- a/src/agent/runtime/turn-sequencing.ts
+++ b/src/agent/runtime/turn-sequencing.ts
@@ -53,6 +53,82 @@ export function focusToolNamesForIntent(allNames: string[] = [], input = ""): st
   return next.length ? next : allNames;
 }
 
+/**
+ * Input carries (or references) an image, audio, video, or YouTube link — the
+ * cases the `multimodal-ingest` skill handles. Used to pre-unlock the deferred
+ * `multimodal` tool group so `vision_analyze`/`audio_analyze`/`youtube_transcribe`
+ * are active on the same turn instead of forcing a tool_activate hop.
+ */
+export const MULTIMODAL_INPUT_RE = new RegExp(
+  [
+    "data:(?:image|audio|video)/",
+    "\\buploads/[^\\s\"']+\\.(?:png|jpe?g|gif|webp|bmp|svg|heic|heif|tiff?|mp3|wav|m4a|aac|ogg|flac|opus|mp4|mov|webm|mkv|avi)\\b",
+    "\\.(?:png|jpe?g|gif|webp|bmp|heic|heif|tiff?|mp3|wav|m4a|aac|ogg|flac|opus|mp4|mov|webm|mkv|avi)\\b",
+    "\\b(?:youtu\\.be/|youtube\\.com/(?:watch\\?|shorts/|embed/|live/))",
+    "\\b(?:this|the|attached|uploaded)\\s+(?:image|photo|screenshot|picture|diagram|chart|audio|recording|video|clip)\\b",
+    "\\btranscribe\\b",
+  ].join("|"),
+  "i"
+);
+
+export function inputSuggestsMultimodal(input) {
+  return MULTIMODAL_INPUT_RE.test(String(input || ""));
+}
+
+/**
+ * Input carries (or references) a ZIP/TAR archive — the `extract_archive` /
+ * `archive_list` case. Used to pre-unlock the deferred `archives` group so the
+ * agent sees the dedicated extract tool instead of flailing with run_python
+ * zipfile (which hits JsProxy/binary errors in Pyodide).
+ */
+export const ARCHIVE_INPUT_RE =
+  /(?:[\w./-]+\.(?:zip|tar|tgz|tar\.gz)\b|\b(?:unzip|extract|decompress)\b[^.!?]{0,40}\b(?:archive|zip|tarball|bundle)\b)/i;
+
+export function inputSuggestsArchive(input) {
+  return ARCHIVE_INPUT_RE.test(String(input || ""));
+}
+
+/**
+ * Input carries (or references) a PDF or DOCX — the `pdf_extract` /
+ * `docx_extract` case. Pre-unlocks the deferred `documents` group.
+ */
+export const DOCUMENT_INPUT_RE = /[\w./-]+\.(?:pdf|docx)\b/i;
+
+export function inputSuggestsDocument(input) {
+  return DOCUMENT_INPUT_RE.test(String(input || ""));
+}
+
+/**
+ * One-shot prefix when the turn references a binary file or media: name the
+ * dedicated tool for the type so the agent does not read_file binary bytes,
+ * run_python zipfile to extract, or shell out (Nodebox has no POSIX shell).
+ */
+export function buildFileHandlingContextPrefix(input) {
+  const text = String(input || "");
+  const archive = inputSuggestsArchive(text);
+  const document = inputSuggestsDocument(text);
+  const media = inputSuggestsMultimodal(text);
+  if (!archive && !document && !media) return null;
+  const lines = [
+    "[File handling] A file/media reference was detected. Use the dedicated tool for its type — do NOT read_file binary bytes, do NOT shell out (Nodebox has no POSIX shell):",
+  ];
+  if (archive) {
+    lines.push(
+      "- ZIP/TAR/TGZ → `extract_archive` (then browse_workspace the output); `archive_list` inspects without extracting. Never run_python zipfile to EXTRACT (os.listdir/binary reads raise JsProxy errors); never read_file the archive."
+    );
+  }
+  if (document) {
+    lines.push("- PDF → `pdf_extract`; DOCX → `docx_extract`. Do not read_file these as text.");
+  }
+  if (media) {
+    lines.push(
+      "- Image → `vision_analyze` / `image_info`; audio → `audio_analyze`; YouTube URL → `youtube_transcribe`."
+    );
+  }
+  lines.push("Full tool picker: skill_view **`browser-runtime-map`**.");
+  return lines.join("\n");
+}
+
 const PYTHON_SKILL_INSTALL_RE = /\b(pip install|python3?|python\s+-m|\.py\b)\b/i;
 
 const API_CALL_INTENT_RE = new RegExp(

--- a/src/agent/runtime/turn.ts
+++ b/src/agent/runtime/turn.ts
@@ -67,6 +67,10 @@ import {
   extractExactResponseTokens,
   repairExactResponseText,
   isResearchIntent,
+  inputSuggestsMultimodal,
+  inputSuggestsArchive,
+  inputSuggestsDocument,
+  buildFileHandlingContextPrefix,
   MIN_RESEARCH_FETCHES,
   MIN_RESEARCH_SEARCHES,
   buildPlanExecutionContextPrefix,
@@ -99,6 +103,7 @@ import {
   resolveInitialActiveToolNames,
   resolvePolicyToolNames,
   canUnlockTool,
+  TOOL_GROUPS,
   type ToolPolicyConfig,
 } from "./tools/tool-policy-config.js";
 import { resolveSkillPrimaryToolsForSlug } from "./memory/skills.js";
@@ -362,6 +367,30 @@ export async function agentTurn(
   const indexPolicyNames = filterToolNames(policyToolNames, turnMeta);
   const filteredPolicyNames = focusToolNamesForIntent(indexPolicyNames, originalUserInput);
   const unlockedTools = new Set<string>();
+  // Pre-unlock deferred file-handling groups when the turn references a binary
+  // file or media so the dedicated tool is active on the same turn instead of
+  // forcing a tool_activate hop (attachments may live in content arrays, not the
+  // input string): multimodal (image/audio/video/YouTube), archives (ZIP/TAR),
+  // documents (PDF/DOCX). Without this the agent never sees extract_archive and
+  // flails with run_python zipfile (JsProxy errors in Pyodide).
+  const recentTurnContent = safeList
+    .slice(-4)
+    .map((message) =>
+      typeof message?.content === "string" ? message.content : JSON.stringify(message?.content ?? "")
+    )
+    .join("\n");
+  const fileSignalBlob = `${originalUserInput}\n${recentTurnContent}`;
+  if (!turnMeta?.textOnly) {
+    const groupsToSeed: string[] = [];
+    if (inputSuggestsMultimodal(fileSignalBlob)) groupsToSeed.push("multimodal");
+    if (inputSuggestsArchive(fileSignalBlob)) groupsToSeed.push("archives");
+    if (inputSuggestsDocument(fileSignalBlob)) groupsToSeed.push("documents");
+    for (const group of groupsToSeed) {
+      for (const name of TOOL_GROUPS[group] || []) {
+        if (canUnlockTool(name, allToolNames, toolPolicy, process.env)) unlockedTools.add(name);
+      }
+    }
+  }
   let activeToolNames = resolveInitialActiveToolNames(
     filteredPolicyNames,
     allToolNames,
@@ -406,6 +435,9 @@ export async function agentTurn(
     !turnMeta?.textOnly && originalUserInput
       ? buildComposioSaasContextPrefix(originalUserInput)
       : null;
+  const fileHandlingPrefix = !turnMeta?.textOnly
+    ? buildFileHandlingContextPrefix(fileSignalBlob)
+    : null;
   const refreshActiveToolState = async () => {
     activeToolNames = resolveInitialActiveToolNames(
       filteredPolicyNames,
@@ -590,6 +622,9 @@ export async function agentTurn(
     composioSaasPrefix !== continuationPrefix
   ) {
     conv.push({ role: "user", content: composioSaasPrefix });
+  }
+  if (fileHandlingPrefix) {
+    conv.push({ role: "user", content: fileHandlingPrefix });
   }
 
   let usedTodoWriteInTurn = false;

--- a/src/runtimes/webcontainer/python.ts
+++ b/src/runtimes/webcontainer/python.ts
@@ -25,6 +25,7 @@ type PythonWorkerResponse = {
   exit_code?: number;
   files?: PythonFilePayload[];
   pyodide_version?: string;
+  sync_note?: string;
 };
 
 const MAX_SYNC_FILES = 800;
@@ -98,17 +99,31 @@ function toBytes(data: unknown): Uint8Array {
   return new Uint8Array();
 }
 
+type SyncSkip = { path: string; bytes: number; reason: string };
+const MAX_SYNC_SKIP_REPORTED = 20;
+
 async function collectFiles(cwd: string): Promise<{
   files: PythonFilePayload[];
   inputByPath: Map<string, string>;
+  skipped: SyncSkip[];
+  truncated: boolean;
 }> {
   const emulator = await getNodebox();
   const files: PythonFilePayload[] = [];
   const inputByPath = new Map<string, string>();
+  const skipped: SyncSkip[] = [];
   let totalBytes = 0;
+  let truncated = false;
+
+  const noteSkip = (path: string, bytes: number, reason: string) => {
+    if (skipped.length < MAX_SYNC_SKIP_REPORTED) skipped.push({ path, bytes, reason });
+  };
 
   async function walk(dir: string): Promise<void> {
-    if (files.length >= MAX_SYNC_FILES || totalBytes >= MAX_SYNC_TOTAL_BYTES) return;
+    if (files.length >= MAX_SYNC_FILES || totalBytes >= MAX_SYNC_TOTAL_BYTES) {
+      truncated = true;
+      return;
+    }
     let names: string[] = [];
     try {
       names = await emulator.fs.readdir(dir);
@@ -116,7 +131,10 @@ async function collectFiles(cwd: string): Promise<{
       return;
     }
     for (const name of names) {
-      if (files.length >= MAX_SYNC_FILES || totalBytes >= MAX_SYNC_TOTAL_BYTES) return;
+      if (files.length >= MAX_SYNC_FILES || totalBytes >= MAX_SYNC_TOTAL_BYTES) {
+        truncated = true;
+        return;
+      }
       const abs = `${dir.replace(/\/+$/, "")}/${name}`;
       const rel = abs.startsWith(`${cwd}/`) ? abs.slice(cwd.length + 1) : name;
       let stat: { type?: string; size?: number };
@@ -132,7 +150,18 @@ async function collectFiles(cwd: string): Promise<{
         continue;
       }
       const size = Number(stat.size ?? 0);
-      if (size > MAX_SYNC_FILE_BYTES || totalBytes + size > MAX_SYNC_TOTAL_BYTES) continue;
+      // A file that exists in the workspace but is too large is otherwise
+      // SILENTLY absent in Pyodide — open() raises FileNotFoundError with no
+      // hint the file is real. Record it so run_python can tell the agent to
+      // use a host tool (extract_archive / read_file / web_fetch) instead.
+      if (size > MAX_SYNC_FILE_BYTES) {
+        noteSkip(rel, size, "file_exceeds_1mb");
+        continue;
+      }
+      if (totalBytes + size > MAX_SYNC_TOTAL_BYTES) {
+        truncated = true;
+        continue;
+      }
       try {
         const contentBase64 = bytesToBase64(toBytes(await emulator.fs.readFile(abs)));
         files.push({ path: abs, contentBase64 });
@@ -145,7 +174,26 @@ async function collectFiles(cwd: string): Promise<{
   }
 
   await walk(cwd);
-  return { files, inputByPath };
+  return { files, inputByPath, skipped, truncated };
+}
+
+/** Human-readable nudge appended to run_python results when workspace files were not synced into Pyodide. */
+export function buildSyncOmissionNote(skipped: SyncSkip[], truncated: boolean): string | null {
+  if (!skipped.length && !truncated) return null;
+  const parts: string[] = [];
+  if (skipped.length) {
+    const list = skipped.map((s) => `${s.path} (${Math.round(s.bytes / 1024)}KB)`).join(", ");
+    parts.push(
+      `These workspace files were too large to load into Python (>1MB) and are NOT visible to open()/os.listdir here: ${list}.`
+    );
+  }
+  if (truncated) {
+    parts.push("The workspace exceeded the Python sync budget, so not all files were loaded.");
+  }
+  parts.push(
+    "They DO exist in the workspace — use a host tool instead: `extract_archive`/`archive_list` for .zip/.tar, `read_file` for text, `pdf_extract`/`docx_extract` for documents, `web_fetch` with save_to for downloads. Do not conclude the file is missing or the runtime is broken."
+  );
+  return parts.join(" ");
 }
 
 async function writeBackFiles(
@@ -207,7 +255,8 @@ async function executePythonNow(req: PythonRequest, workspaceRoot: string) {
     typeof req.timeout_ms === "number" && Number.isFinite(req.timeout_ms) && req.timeout_ms > 0
       ? req.timeout_ms
       : 120_000;
-  const { files, inputByPath } = await collectFiles(cwd);
+  const { files, inputByPath, skipped, truncated } = await collectFiles(cwd);
+  const syncNote = buildSyncOmissionNote(skipped, truncated);
   const response = await postWorker({
     code: String(req.code || ""),
     cwd,
@@ -226,7 +275,7 @@ async function executePythonNow(req: PythonRequest, workspaceRoot: string) {
     // postMessage crash). Recycle the worker so the next run starts clean
     // instead of inheriting the broken FS / module state.
     resetWorker();
-    return response;
+    return syncNote ? { ...response, sync_note: syncNote } : response;
   }
   const files_written = await writeBackFiles(cwd, inputByPath, response.files || []);
   return {
@@ -236,6 +285,7 @@ async function executePythonNow(req: PythonRequest, workspaceRoot: string) {
     exit_code: Number(response.exit_code ?? 0),
     files_written,
     pyodide_version: response.pyodide_version || "",
+    ...(syncNote ? { sync_note: syncNote } : {}),
   };
 }
 

--- a/tests/error-classifier.test.ts
+++ b/tests/error-classifier.test.ts
@@ -35,6 +35,20 @@ test("classifyToolError treats run_shell aborted as non-retryable aborted", () =
   assert.equal(c.retryable, false);
 });
 
+test("classifyToolError redirects run_python zipfile extraction to extract_archive", () => {
+  const c = classifyToolError(
+    "PythonError: zipfile.ZipFile(...).extractall failed; os.listdir returned pyodide.ffi.JsProxy"
+  );
+  assert.equal(c.error_code, "pyodide_archive_misuse");
+  assert.equal(c.retryable, false);
+  assert.match(c.recovery_hint, /extract_archive/);
+});
+
+test("classifyToolError keeps urllib JsProxy as HTTP misroute, not archive", () => {
+  const c = classifyToolError("pyodide.ffi.JsProxy from urllib.request.urlopen");
+  assert.equal(c.error_code, "pyodide_http_jsproxy");
+});
+
 test("classifyToolError does not treat generic 'abort' substring as timeout/retryable", () => {
   const c = classifyToolError("Something went wrong: abortedConnection=true");
   assert.notEqual(c.error_code, "timeout");

--- a/tests/read-file-cap.test.ts
+++ b/tests/read-file-cap.test.ts
@@ -1,7 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { getReadFileMaxChars } from "../dist/agent-runtime/tools/filesystem/read.js";
+import {
+  getReadFileMaxChars,
+  binaryReadRecovery,
+} from "../dist/agent-runtime/tools/filesystem/read.js";
 
 test("getReadFileMaxChars defaults to snapshot unwrap cap", () => {
   const prev = process.env.WEBAGENT_READ_FILE_MAX_CHARS;
@@ -12,4 +15,18 @@ test("getReadFileMaxChars defaults to snapshot unwrap cap", () => {
     if (prev != null) process.env.WEBAGENT_READ_FILE_MAX_CHARS = prev;
     else delete process.env.WEBAGENT_READ_FILE_MAX_CHARS;
   }
+});
+
+test("binaryReadRecovery redirects binary/media reads to the right tool", () => {
+  assert.match(binaryReadRecovery("uploads/skill.zip"), /extract_archive/);
+  assert.match(binaryReadRecovery("work/bundle.tar.gz"), /extract_archive/);
+  assert.match(binaryReadRecovery("report.pdf"), /pdf_extract/);
+  assert.match(binaryReadRecovery("contract.docx"), /docx_extract/);
+  assert.match(binaryReadRecovery("uploads/photo.JPG"), /vision_analyze/);
+  assert.match(binaryReadRecovery("clip.mp3"), /audio_analyze/);
+  // Text-readable files are not blocked.
+  assert.equal(binaryReadRecovery("README.md"), null);
+  assert.equal(binaryReadRecovery("src/index.ts"), null);
+  assert.equal(binaryReadRecovery("data.json"), null);
+  assert.equal(binaryReadRecovery(""), null);
 });

--- a/tests/research-sequencing.test.ts
+++ b/tests/research-sequencing.test.ts
@@ -1,7 +1,13 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { isResearchIntent } from "../dist/agent-runtime/turn-sequencing.js";
+import {
+  isResearchIntent,
+  inputSuggestsMultimodal,
+  inputSuggestsArchive,
+  inputSuggestsDocument,
+  buildFileHandlingContextPrefix,
+} from "../dist/agent-runtime/turn-sequencing.js";
 
 const BENCHMARK_PROMPT =
   "Please help me find YouTubers in UAE and KSA posting about openclaw and hermes agent";
@@ -12,4 +18,47 @@ test("isResearchIntent matches benchmark discover prompt", () => {
 
 test("isResearchIntent is false for unrelated tasks", () => {
   assert.equal(isResearchIntent("Fix the typo in README.md"), false);
+});
+
+test("inputSuggestsMultimodal detects attachments, data URLs, and YouTube links", () => {
+  assert.equal(inputSuggestsMultimodal("what is in this screenshot?"), true);
+  assert.equal(inputSuggestsMultimodal("uploads/diagram.png"), true);
+  assert.equal(inputSuggestsMultimodal("describe photo.jpeg"), true);
+  assert.equal(inputSuggestsMultimodal("transcribe https://youtu.be/abc123"), true);
+  assert.equal(inputSuggestsMultimodal('{"type":"image_url","image_url":{"url":"data:image/png;base64,iVBOR"}}'), true);
+  assert.equal(inputSuggestsMultimodal("transcribe this recording"), true);
+  // No false positive on plain text tasks.
+  assert.equal(inputSuggestsMultimodal("Fix the typo in README.md"), false);
+  assert.equal(inputSuggestsMultimodal("Summarize the quarterly report"), false);
+});
+
+test("inputSuggestsArchive detects archive uploads and extract intent", () => {
+  assert.equal(inputSuggestsArchive("uploads/directus-5lang-blog-publisher2.zip"), true);
+  assert.equal(inputSuggestsArchive("here is the bundle.tar.gz"), true);
+  assert.equal(inputSuggestsArchive("data.tgz"), true);
+  assert.equal(inputSuggestsArchive("please unzip this archive"), true);
+  // No false positive on plain text / unrelated extensions.
+  assert.equal(inputSuggestsArchive("Fix the typo in README.md"), false);
+  assert.equal(inputSuggestsArchive("read config.json"), false);
+});
+
+test("inputSuggestsDocument detects pdf and docx references", () => {
+  assert.equal(inputSuggestsDocument("uploads/report.pdf"), true);
+  assert.equal(inputSuggestsDocument("summarize contract.docx"), true);
+  assert.equal(inputSuggestsDocument("Fix the typo in README.md"), false);
+});
+
+test("buildFileHandlingContextPrefix routes each file type to its tool", () => {
+  const zipPrefix = buildFileHandlingContextPrefix("uploads/skill.zip");
+  assert.match(zipPrefix, /extract_archive/);
+  assert.match(zipPrefix, /Never run_python zipfile to EXTRACT/);
+
+  const pdfPrefix = buildFileHandlingContextPrefix("uploads/report.pdf");
+  assert.match(pdfPrefix, /pdf_extract/);
+
+  const imgPrefix = buildFileHandlingContextPrefix("what is in uploads/diagram.png?");
+  assert.match(imgPrefix, /vision_analyze/);
+
+  // Plain-text task → no prefix.
+  assert.equal(buildFileHandlingContextPrefix("Fix the typo in README.md"), null);
 });

--- a/tests/streaming-sanitize.test.ts
+++ b/tests/streaming-sanitize.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import {
   createToolAwareStreamWriter,
+  estimateMessageTokens,
   extractClarifyMarkers,
   extractLooseCallToolLines,
   extractPlainToolCommandLines,
@@ -14,6 +15,29 @@ import {
   stripPseudoToolCallLines,
   stripReasoningPlaceholderLines,
 } from "../dist/agent-runtime/llm/streaming.js";
+
+test("estimateMessageTokens counts array content and tool_calls, not [object Object]", () => {
+  const longText = "x".repeat(4000);
+  const stringMsg = { role: "user", content: longText };
+  const arrayMsg = {
+    role: "user",
+    content: [{ type: "text", text: longText }, { type: "image_url", image_url: { url: longText } }],
+  };
+  // Array content must count its parts, not collapse to "[object Object]" (~4 tokens).
+  assert.ok(estimateMessageTokens(arrayMsg) > estimateMessageTokens(stringMsg));
+  assert.ok(estimateMessageTokens(arrayMsg) > 1000);
+
+  // Assistant tool_calls payloads are real tokens even when content is null.
+  const toolCallMsg = {
+    role: "assistant",
+    content: null,
+    tool_calls: [{ function: { name: "web_fetch", arguments: JSON.stringify({ url: longText }) } }],
+  };
+  assert.ok(estimateMessageTokens(toolCallMsg) > 900);
+
+  // Empty/short messages stay cheap.
+  assert.ok(estimateMessageTokens({ role: "user", content: "" }) < 10);
+});
 
 test("sanitizeAssistantVisibleText strips pseudo tool lines when names provided", () => {
   const raw = `I'll scan the tree.

--- a/tests/tool-coverage-execution.test.ts
+++ b/tests/tool-coverage-execution.test.ts
@@ -158,6 +158,74 @@ test("composio_status reports missing configuration without network", async () =
   assert.ok((result.allowed_actions?.length ?? 0) >= 5);
 });
 
+test("every tool error carries a recovery_hint (classifier routing)", async () => {
+  // Pillar 3 — tool failures must route through classifyToolError so domain
+  // recovery hints always reach the agent. read_file on an archive triggers the
+  // binary-read guard end-to-end: guard throws -> classifier delivers the hint.
+  await withIsolatedWorkspace(async () => {
+    const catalog = await loadToolCatalog();
+    const out = (await runOne("read_file", { path: "bundle.zip" }, catalog)) as {
+      error?: string;
+      recovery_hint?: string;
+      error_code?: string;
+    };
+    assert.ok(out?.error, "read_file on a .zip should error");
+    assert.ok(out?.recovery_hint, "tool error should carry a recovery_hint from the classifier");
+    assert.ok(out?.error_code, "tool error should carry an error_code from the classifier");
+  });
+});
+
+test("no silent no-op: every required-field tool rejects empty input", async () => {
+  // Pillar 2 — a tool that declares required schema fields must LOUDLY reject a
+  // call missing them (error_code invalid_arguments), never silently succeed.
+  // Enforced centrally in runTools, so adding a required field to any tool's
+  // schema automatically gets this protection — and new tools inherit it.
+  await withIsolatedWorkspace(async () => {
+    const catalog = await loadToolCatalog();
+    const checked: string[] = [];
+    for (const [name, def] of Object.entries(BUILTIN_TOOLS)) {
+      const required = (def as { inputSchema?: { required?: string[] } })?.inputSchema?.required;
+      if (!Array.isArray(required) || required.length === 0) continue;
+      checked.push(name);
+      const out = (await runOne(name, {}, catalog)) as { error?: string; error_code?: string };
+      assert.ok(out?.error, `${name} should error on empty args, not silently succeed`);
+      assert.equal(
+        out?.error_code,
+        "invalid_arguments",
+        `${name} empty-args error should be classified invalid_arguments`
+      );
+    }
+    assert.ok(checked.length >= 8, `expected several required-field tools, saw ${checked.length}`);
+  });
+});
+
+test("todo_write accepts items/text aliases and rejects empty lists", async () => {
+  await withIsolatedWorkspace(async () => {
+    const catalog = await loadToolCatalog();
+    // Regression: the model passes `items` with `text`/`title`, not `todos`/`content`.
+    const out = await runOne(
+      "todo_write",
+      {
+        items: [
+          { id: 1, text: "Get transcript", status: "in_progress" },
+          { id: 2, title: "Write article", status: "pending" },
+        ],
+      },
+      catalog
+    );
+    assert.ok(!out?.error, out?.error);
+    assert.equal((out?.result as { count?: number }).count, 2);
+    const root = process.env.WEBAGENT_WORKSPACE_ROOT || "";
+    const saved = JSON.parse(await fs.readFile(nodePath.join(root, ".webagent/todos.json"), "utf8"));
+    assert.equal(saved[0].content, "Get transcript");
+    assert.equal(saved[1].content, "Write article");
+
+    // An explicit but empty list is an error, not a silent count:0 success.
+    const empty = await runOne("todo_write", { todos: [] }, catalog);
+    assert.ok(empty?.error, "empty todo list should surface an error");
+  });
+});
+
 test("archive tools honor explicit archive_path and extract skill archives", async () => {
   await withIsolatedWorkspace(async () => {
     const catalog = await loadToolCatalog();

--- a/tests/tool-registry-catalog.test.ts
+++ b/tests/tool-registry-catalog.test.ts
@@ -82,6 +82,30 @@ test("built-in tool registry and catalog keys match", async () => {
   }
 });
 
+// Pillar 1 — schema visibility. A tool with a contentless inputSchema is a
+// black hole: the model gets no shape signal and validateRequiredArguments has
+// nothing to check, so wrong-shaped args (e.g. todo_write's `items`) get eaten
+// silently. Every builtin must declare its properties, except genuine no-arg
+// tools listed here. Adding a new contentless-schema tool must fail this test.
+const NO_ARG_TOOLS = new Set(["cron_list", "skill_list", "system_info"]);
+
+test("every builtin declares an input schema (no black-hole tools)", async () => {
+  const registry = await import("../dist/agent-runtime/tools/registry.js");
+  const offenders: string[] = [];
+  for (const [name, def] of Object.entries(registry.BUILTIN_TOOLS)) {
+    if (NO_ARG_TOOLS.has(name)) continue;
+    const props = (def as { inputSchema?: { properties?: Record<string, unknown> } })?.inputSchema
+      ?.properties;
+    const count = props && typeof props === "object" ? Object.keys(props).length : 0;
+    if (count === 0) offenders.push(name);
+  }
+  assert.deepEqual(
+    offenders,
+    [],
+    `These tools ship a contentless inputSchema. Declare their properties, or add to NO_ARG_TOOLS if they truly take no args: ${offenders.join(", ")}`
+  );
+});
+
 test("buildOpenAiToolDefinitions omits llmVisible:false alias tools", async () => {
   const registry = await import("../dist/agent-runtime/tools/registry.js");
   const catalog = await registry.loadToolCatalog();

--- a/tests/tool-search.test.ts
+++ b/tests/tool-search.test.ts
@@ -12,6 +12,25 @@ test("isDeferredCatalogTool marks llmVisible false but not mcp tools", () => {
   assert.equal(isDeferredCatalogTool("read_file", {}), false);
 });
 
+test("isDeferredCatalogTool recognizes group-deferred tools not marked llmVisible", () => {
+  // Regression: extract_archive is deferred via DEFERRED_TOOL_GROUPS, not via
+  // llmVisible:false. Before the fix, tool_search could not find it by name —
+  // even when the user said "use the extract_archive tool".
+  assert.equal(isDeferredCatalogTool("extract_archive", {}), true);
+  assert.equal(isDeferredCatalogTool("archive_list", {}), true);
+  assert.equal(isDeferredCatalogTool("pdf_extract", {}), true);
+});
+
+test("searchDeferredTools finds a group-deferred tool by exact name", async () => {
+  const catalog = {
+    extract_archive: { description: "Extract a ZIP, TAR, or TAR.GZ archive into a workspace directory." },
+    read_file: { description: "Read a file." },
+  };
+  const matches = await searchDeferredTools("extract_archive", new Set(["read_file"]), 12, catalog);
+  assert.equal(matches.length, 1);
+  assert.equal(matches[0].name, "extract_archive");
+});
+
 test("tool_activate schema requires name", async () => {
   const mod = await import("../dist/agent-runtime/tools/builtins/tool_activate.js");
   assert.equal(mod.default.name, "tool_activate");

--- a/tests/web-http-tools.test.ts
+++ b/tests/web-http-tools.test.ts
@@ -86,6 +86,24 @@ test("graphqlSchemaRecoveryHint points to skill discovery", () => {
   assert.doesNotMatch(String(hint), /directus/i);
 });
 
+test("graphqlSchemaRecoveryHint teaches relation linking on input-shape error", () => {
+  const data = {
+    errors: [
+      {
+        message: 'Field "name" of required type "String!" was not provided.',
+        extensions: { code: "GRAPHQL_VALIDATION_EXCEPTION" },
+      },
+      { message: 'Expected value of type "create_Blog_Authors_input".' },
+    ],
+  };
+  const hint = graphqlSchemaRecoveryHint(data, 400);
+  assert.match(String(hint), /id/);
+  assert.match(String(hint), /variables/i);
+  assert.match(String(hint), /http-api/);
+  // Stays generic — no hardcoded customer collection names.
+  assert.doesNotMatch(String(hint), /directus/i);
+});
+
 test("guessedResourceRecoveryHint nudges discovery after deep-path 403", () => {
   const hint = guessedResourceRecoveryHint("https://api.example.com/v1/items/posts?limit=0", 403);
   assert.match(String(hint), /skill_view/i);


### PR DESCRIPTION
Fix the failure class behind stranded zip extraction and blocked blog publish: tools that silently no-op or hide their schema, leading the agent to confabulate ("os.listdir JsProxy bug", "no archive tool exists").

File-type / runtime handling:
- read_file: binary-extension guard redirects archives/PDF/DOCX/media to the right tool instead of returning utf8 mojibake
- error-classifier: redirect run_python zipfile/JsProxy extraction to extract_archive; broaden graphqlSchemaRecoveryHint to teach relation linking ({id}) + variables on input-shape errors
- turn: pre-unlock archives/documents/multimodal groups on file mention; inject a file-handling context prefix
- tool_search: surface group-deferred tools (extract_archive et al.) that are not marked llmVisible:false — was structurally unfindable by name
- python.ts: surface a sync_note when workspace files are omitted from the Pyodide FS (>1MB / budget) instead of a silent FileNotFoundError

Tool I/O fixes:
- todo_write: accept items/tasks + text/title aliases, numeric ids, mkdir parent dir, error on empty list (was silent count:0); real schema
- skill_manage write_file: reject empty content (was blank support files)

Systemic invariants (catch the class without a transcript):
- schema-visibility lint: no builtin ships a contentless inputSchema (8 tools given real schemas; 3 no-arg tools exempt)
- no-silent-noop: every required-field tool loudly rejects empty input
- classifier-routing lock: every tool error carries recovery_hint

886 tests, 885 pass, 1 skip (composio-live), tsc clean.

## Summary

- what changed
- why it changed

## Verification

- [ ] `npm run test`
- [ ] `npm run build`
- [ ] manual check if UI behavior changed

## Notes

- keep changes surgical
- call out persistence, isolation, or security impact when relevant
