### PR TITLE
chore: sync package-lock.json version with package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-agent",
-  "version": "0.0.68",
+  "version": "0.0.72",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-agent",
-      "version": "0.0.68",
+      "version": "0.0.72",
       "dependencies": {
         "@codesandbox/nodebox": "^0.1.9",
         "@huggingface/transformers": "^3.8.1",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`package.json` on `main` is at `0.0.72`, but `package-lock.json` still listed `0.0.68` in the root `version` fields. This updates the lockfile to match.

## Changes

- Bump root `version` in `package-lock.json` from `0.0.68` to `0.0.72` (no dependency changes).

## Testing

- No runtime impact; version metadata only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-89c2ac32-e7e6-4de5-97b3-72201ee31270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-89c2ac32-e7e6-4de5-97b3-72201ee31270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

