### PR TITLE
fix: restore browser UI and Nodebox agent boot

### DIFF
--- a/src/agent/adapter.ts
+++ b/src/agent/adapter.ts
@@ -385,6 +385,8 @@ async function ensureOnboardingFiles(profileId: string): Promise<void> {
     await emulator.fs.writeFile(cronjobsPath, JSON.stringify({ jobs: [] }, null, 2));
   }
 
+  await emulator.fs.mkdir(`${workspaceDir}/.webagent/skills`, { recursive: true });
+
   const toolPolicyPath = `${workspaceDir}/.webagent/tool-policy.json`;
   try {
     await emulator.fs.readFile(toolPolicyPath);
@@ -528,6 +530,7 @@ function buildEnv(profileId: string, profile: Profile, apiKeys: Record<string, s
     WEBAGENT_MEMORY_ROOT: `${profileWorkspaceRoot}/memory`,
     WEBAGENT_DEBUG_LOG: VITE_DEBUG_LOG_ENABLED ? "1" : "0",
     WEBAGENT_DEBUG_LOG_DIR: RUNTIME_DEBUG_LOG_DIR,
+    ...(import.meta.env.DEV ? { WEBAGENT_PROXY_ALLOW_PRIVATE: "1" } : {}),
     ...(autoApproveTools ? { WEBAGENT_AUTO_APPROVE_TOOLS: "1" } : {}),
     ...toolGuardrailsEnvForRuntime(import.meta.env),
   };

--- a/src/agent/runtime/channels/index.ts
+++ b/src/agent/runtime/channels/index.ts
@@ -1,13 +1,13 @@
 import fs from "node:fs/promises";
 import nodePath from "node:path";
 import { pathToFileURL } from "node:url";
-import { CAPABILITIES_DIR } from "../constants.js";
+import { getCapabilitiesDir } from "../constants.js";
 import { createChannelInboundHandler } from "./dispatcher.js";
 
 async function loadCapabilityChannel(id) {
   const safeId = String(id || "").trim();
   if (!/^[a-z][a-z0-9_-]*$/.test(safeId)) return null;
-  const dir = nodePath.join(CAPABILITIES_DIR, "channels", safeId);
+  const dir = nodePath.join(getCapabilitiesDir(), "channels", safeId);
   const runtimePath = nodePath.join(dir, "runtime.js");
   const manifestPath = nodePath.join(dir, "manifest.json");
   const stat = await fs.stat(runtimePath).catch(() => null);

--- a/src/agent/runtime/constants.ts
+++ b/src/agent/runtime/constants.ts
@@ -1,11 +1,21 @@
-let WS_VALUE = "/workspace";
-let ROOT_VALUE = "/workspace";
-
-if (typeof process !== "undefined" && process.cwd) {
-  WS_VALUE = process.cwd();
-  // Use process.cwd() as ROOT; path.resolve() not available at module init time
-  ROOT_VALUE = WS_VALUE;
+function ensurePosixAbsolutePath(value: string, defaultRoot = "/workspace"): string {
+  const s = String(value || "").trim().replace(/\\/g, "/");
+  if (!s) return defaultRoot;
+  if (s.startsWith("/")) return s.replace(/\/+$/, "") || "/";
+  const parts = s.split("/").filter(Boolean);
+  if (parts[0] === "workspace") return `/${parts.join("/")}`;
+  return posixResolve(defaultRoot, s);
 }
+
+function readInitialWorkspaceRoot(): string {
+  if (typeof process === "undefined") return "/workspace";
+  const fromEnv = String(process.env?.WEBAGENT_WORKSPACE_ROOT || "").trim();
+  const raw = fromEnv || (typeof process.cwd === "function" ? process.cwd() : "");
+  return ensurePosixAbsolutePath(raw || "/workspace");
+}
+
+let WS_VALUE = readInitialWorkspaceRoot();
+let ROOT_VALUE = WS_VALUE;
 
 export const WS = WS_VALUE;
 export const WORKSPACE_LABEL = "/workspace";
@@ -60,6 +70,14 @@ export function workspaceStatePath(relativePath: string): string {
 
 export function getMemoryRoot(): string {
   return toAbsoluteRoot(envPathOverride("WEBAGENT_MEMORY_ROOT") || `${getRuntimeRoot()}/memory`);
+}
+
+export function getSkillsDir(): string {
+  return `${getWorkspaceRoot()}/.webagent/skills`;
+}
+
+export function getCapabilitiesDir(): string {
+  return `${getWorkspaceRoot()}/.webagent/capabilities`;
 }
 
 export function memoryStatePath(relativePath: string): string {

--- a/src/agent/runtime/constants.ts
+++ b/src/agent/runtime/constants.ts
@@ -1,5 +1,3 @@
-import nodePath from "node:path";
-
 let WS_VALUE = "/workspace";
 let ROOT_VALUE = "/workspace";
 
@@ -23,14 +21,29 @@ function envPathOverride(name: string): string {
 }
 
 export function isNodeboxRuntime(): boolean {
-  return String(process.env.WEBAGENT_RUNTIME ?? "").trim() === "nodebox";
+  return String(typeof process !== "undefined" ? process.env?.WEBAGENT_RUNTIME : "").trim() === "nodebox";
+}
+
+function isPosixAbsolute(value: string): boolean {
+  return value.startsWith("/");
+}
+
+function posixResolve(base: string, rel: string): string {
+  const parts = [...base.split("/").filter(Boolean), ...rel.split("/")];
+  const out: string[] = [];
+  for (const part of parts) {
+    if (!part || part === ".") continue;
+    if (part === "..") out.pop();
+    else out.push(part);
+  }
+  return `/${out.join("/")}`;
 }
 
 /** Resolve any root override to an absolute path so host/sandbox/module-init all agree. Relative overrides are anchored to cwd (`WS`). */
 function toAbsoluteRoot(value: string): string {
   const s = String(value || "").trim();
   if (!s) return WS;
-  return nodePath.isAbsolute(s) ? s : nodePath.resolve(WS, s);
+  return isPosixAbsolute(s) ? s : posixResolve(WS, s);
 }
 
 export function getWorkspaceRoot(): string {

--- a/src/agent/runtime/curator.ts
+++ b/src/agent/runtime/curator.ts
@@ -4,7 +4,7 @@
 
 import fs from "node:fs/promises";
 import nodePath from "node:path";
-import { SKILLS_DIR, workspaceStatePath } from "./constants.js";
+import { getSkillsDir, workspaceStatePath } from "./constants.js";
 import { dim } from "./terminal-format.js";
 import { logDebugEvent } from "./logging/debug-log.js";
 import { emitSelfImprovementSummary } from "./identity/onboarding.js";
@@ -78,7 +78,7 @@ export async function loadCuratorState(): Promise<CuratorState> {
 }
 
 async function saveCuratorState(state: CuratorState): Promise<void> {
-  await fs.mkdir(SKILLS_DIR, { recursive: true });
+  await fs.mkdir(getSkillsDir(), { recursive: true });
   await fs.writeFile(CURATOR_STATE_PATH, JSON.stringify(state, null, 2), "utf8");
 }
 
@@ -234,7 +234,7 @@ export async function archiveAgentSkillBySlug(slug: string, absorbedInto?: strin
   if (!skill || skill.source === "bundled") {
     throw new Error(`skill curator: '${slug}' not found or protected.`);
   }
-  const dir = nodePath.join(SKILLS_DIR, skill.category, slug);
+  const dir = nodePath.join(getSkillsDir(), skill.category, slug);
   await archiveSkillDirectory(dir, slug, absorbedInto || null);
 }
 

--- a/src/agent/runtime/mcp-config.ts
+++ b/src/agent/runtime/mcp-config.ts
@@ -1,29 +1,65 @@
-import {
-  interpolateEnvString,
-  parseMcpServersConfig,
-  loadMcpServersConfigFromPath,
-  saveMcpServersConfigToPath,
-} from "../../core/mcp/config.js";
-import type { McpServerConfig, McpServersConfig } from "../../core/mcp/types.js";
+import fs from "node:fs/promises";
 import { MCP_SERVERS_REL, workspaceStatePath } from "./constants.js";
 import { loadMcpSecrets, mcpSecretsToEnv } from "./mcp-secrets.js";
 
-export type { McpServerConfig, McpServersConfig } from "../../core/mcp/types.js";
+export type McpToolsFilter = {
+  include?: string[];
+  exclude?: string[];
+  resources?: boolean;
+  prompts?: boolean;
+};
+
+export type McpServerConfig = {
+  command?: string;
+  args?: string[];
+  url?: string;
+  transport?: "sse" | "streamable-http";
+  env?: Record<string, string>;
+  headers?: Record<string, string>;
+  enabled?: boolean;
+  timeout?: number;
+  connect_timeout?: number;
+  tools?: McpToolsFilter;
+};
+
+export type McpServersConfig = Record<string, McpServerConfig>;
 
 const ENV_VAR_PATTERN = /\$\{([^}]+)\}/g;
+
+function interpolateEnvString(text: string, env: Record<string, string>): string {
+  return String(text || "").replace(ENV_VAR_PATTERN, (_, name: string) => {
+    const key = String(name || "").trim();
+    return key && env[key] != null ? String(env[key]) : "";
+  });
+}
 
 export function mcpConfigPath(): string {
   return workspaceStatePath(MCP_SERVERS_REL);
 }
 
-export { parseMcpServersConfig };
+export function parseMcpServersConfig(raw: unknown): McpServersConfig {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
+  const out: McpServersConfig = {};
+  for (const [name, value] of Object.entries(raw)) {
+    if (!name.trim() || !value || typeof value !== "object" || Array.isArray(value)) continue;
+    out[name] = value as McpServerConfig;
+  }
+  return out;
+}
 
 export async function loadMcpServersConfig(): Promise<McpServersConfig> {
-  return loadMcpServersConfigFromPath(mcpConfigPath());
+  try {
+    const raw = await fs.readFile(mcpConfigPath(), "utf8");
+    return parseMcpServersConfig(JSON.parse(raw));
+  } catch {
+    return {};
+  }
 }
 
 export async function saveMcpServersConfig(config: McpServersConfig): Promise<void> {
-  return saveMcpServersConfigToPath(mcpConfigPath(), config);
+  const path = mcpConfigPath();
+  await fs.mkdir(path.replace(/\/[^/]+$/, ""), { recursive: true });
+  await fs.writeFile(path, `${JSON.stringify(config, null, 2)}\n`, "utf8");
 }
 
 function collectEnvVarRefs(config: McpServersConfig): Set<string> {

--- a/src/agent/runtime/memory/skills.ts
+++ b/src/agent/runtime/memory/skills.ts
@@ -4,11 +4,7 @@
 
 import fs from "node:fs/promises";
 import nodePath from "node:path";
-import {
-  CAPABILITIES_DIR,
-  SKILLS_DIR,
-  WS,
-} from "../constants.js";
+import { getCapabilitiesDir, getSkillsDir, WS } from "../constants.js";
 import { resolveWorkspacePath } from "../workspace-paths.js";
 import { errorMessage } from "../utils.js";
 import {
@@ -47,7 +43,7 @@ const SKILL_EXCLUDED_DIRS = new Set(["tests", "examples", "node_modules", ".git"
 const SKILL_SUPPORT_MAX_FILES = 64;
 const SKILL_SUPPORT_MAX_TOTAL_BYTES = 2 * 1024 * 1024;
 const SKILL_SAFE_FILE_MAX_BYTES = 512 * 1024;
-const BUNDLED_SKILLS_DIR = nodePath.join(CAPABILITIES_DIR, "skills");
+const bundledSkillsDir = () => nodePath.join(getCapabilitiesDir(), "skills");
 const MAX_BULK_SKILL_ITEMS = 75;
 const BUNDLED_SKILL_PRIMARY_TOOLS: Record<string, string[]> = {};
 
@@ -262,15 +258,16 @@ function skillPublicPath(absPath) {
 }
 
 function canonicalSkillDir({ category, slug }) {
-  return nodePath.join(SKILLS_DIR, skillCategorySlug(category), skillSlug(slug));
+  return nodePath.join(getSkillsDir(), skillCategorySlug(category), skillSlug(slug));
 }
 
 async function migrateLegacySkillFiles() {
-  await fs.mkdir(SKILLS_DIR, { recursive: true });
-  const entries = await fs.readdir(SKILLS_DIR, { withFileTypes: true }).catch(() => []);
+  const skillsDir = getSkillsDir();
+  await fs.mkdir(skillsDir, { recursive: true });
+  const entries = await fs.readdir(skillsDir, { withFileTypes: true }).catch(() => []);
   for (const entry of entries) {
     if (!entry.isFile() || !entry.name.endsWith(".md")) continue;
-    const legacyPath = nodePath.join(SKILLS_DIR, entry.name);
+    const legacyPath = nodePath.join(skillsDir, entry.name);
     const raw = await fs.readFile(legacyPath, "utf8").catch(() => "");
     if (!raw.trim()) continue;
     let nextRaw = raw;
@@ -349,8 +346,8 @@ async function collectSkillRecords(): Promise<SkillRecord[]> {
       await walk(abs, source);
     }
   };
-  await walk(SKILLS_DIR, "local");
-  await walk(BUNDLED_SKILLS_DIR, "bundled");
+  await walk(getSkillsDir(), "local");
+  await walk(bundledSkillsDir(), "bundled");
   if (!records.some((record) => record.source === "bundled")) {
     await walk(nodePath.join(WS, "src", "capabilities", "skills"), "bundled");
   }
@@ -793,7 +790,7 @@ async function installSkillFromUrl({ url, category }) {
     category: String(category || validation.meta.category || "imported"),
     content: patchedRaw,
   });
-  const hubDir = nodePath.join(SKILLS_DIR, ".hub");
+  const hubDir = nodePath.join(getSkillsDir(), ".hub");
   await fs.mkdir(hubDir, { recursive: true });
   await recordSkillHubLock(result.slug, {
     source: normalizedUrl,

--- a/src/agent/runtime/tools/tool-loader.ts
+++ b/src/agent/runtime/tools/tool-loader.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import nodePath from "node:path";
 import { pathToFileURL } from "node:url";
-import { CAPABILITIES_DIR, WS } from "../constants.js";
+import { getCapabilitiesDir, WS } from "../constants.js";
 import { logDebugEvent } from "../logging/debug-log.js";
 import { errorMessage } from "../utils.js";
 import { BUILTIN_TOOL_DEFINITIONS } from "./builtins/index.js";
@@ -62,7 +62,7 @@ let capabilityToolCatalogCache: Record<string, CapabilityCatalogEntry> | null = 
 
 function capabilityToolRoots() {
   return [
-    nodePath.join(CAPABILITIES_DIR, "tools"),
+    nodePath.join(getCapabilitiesDir(), "tools"),
     nodePath.join(WS, "src", "capabilities", "tools"),
   ];
 }

--- a/src/core/mcp/server-task.ts
+++ b/src/core/mcp/server-task.ts
@@ -10,7 +10,10 @@ import { createMcpCorsProxyFetch } from "./cors-proxy-fetch.js";
 const DEFAULT_CONNECT_TIMEOUT = 60_000;
 const MAX_FAILURES = 3;
 const CIRCUIT_COOLDOWN_MS = 60_000;
-const MAX_TOOLS_PER_SERVER = Math.max(1, Number(process.env.WEBAGENT_MCP_TOOLS_PER_SERVER_CAP) || 30);
+const MAX_TOOLS_PER_SERVER = Math.max(
+  1,
+  Number(typeof process !== "undefined" ? process.env?.WEBAGENT_MCP_TOOLS_PER_SERVER_CAP : undefined) || 30
+);
 
 const CREDENTIAL_PATTERN =
   /(?:ghp_[A-Za-z0-9_]{1,255}|sk-[A-Za-z0-9_]{1,255}|Bearer\s+\S+|token=[^\s&,;"']{1,255}|key=[^\s&,;"']{1,255}|API_KEY=[^\s&,;"']{1,255}|password=[^\s&,;"']{1,255}|secret=[^\s&,;"']{1,255})/gi;

--- a/tests/workspace-root-init.test.ts
+++ b/tests/workspace-root-init.test.ts
@@ -1,0 +1,15 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+test("readInitialWorkspaceRoot prefers WEBAGENT_WORKSPACE_ROOT and normalizes relative cwd", async () => {
+  const prev = process.env.WEBAGENT_WORKSPACE_ROOT;
+  process.env.WEBAGENT_WORKSPACE_ROOT = "/workspace/test-profile";
+  try {
+    const mod = await import(`../dist/agent-runtime/constants.js?v=${Date.now()}`);
+    assert.equal(mod.getWorkspaceRoot(), "/workspace/test-profile");
+    assert.equal(mod.getSkillsDir(), "/workspace/test-profile/.webagent/skills");
+  } finally {
+    if (prev === undefined) delete process.env.WEBAGENT_WORKSPACE_ROOT;
+    else process.env.WEBAGENT_WORKSPACE_ROOT = prev;
+  }
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -207,7 +207,7 @@ function edgeTtsGate() {
   };
 }
 
-function corsProxyGate() {
+function corsProxyGate(proxyEnv: Record<string, string | undefined>) {
   const gate = (server: {
     middlewares: {
       use: (fn: (req: IncomingMessage, res: import("node:http").ServerResponse, next: () => void) => void) => void;
@@ -244,7 +244,7 @@ function corsProxyGate() {
             Buffer.concat(chunks).toString("utf8")
           );
           try {
-            assertProxyTargetAllowed(url);
+            assertProxyTargetAllowed(url, proxyEnv);
           } catch (blockErr) {
             res.statusCode = 403;
             res.setHeader("content-type", "application/json");
@@ -476,6 +476,12 @@ const LLM_PROXIES = buildLlmProxies();
 
 export default defineConfig(({ mode }) => {
   APP_ENV = loadEnv(mode, process.cwd(), "");
+  const proxyEnv: Record<string, string | undefined> = {
+    ...process.env,
+    WEBAGENT_PROXY_ALLOW_PRIVATE:
+      APP_ENV.WEBAGENT_PROXY_ALLOW_PRIVATE ||
+      (mode === "development" ? "1" : process.env.WEBAGENT_PROXY_ALLOW_PRIVATE),
+  };
   if (mode === "production" && !isTransitOnlyProxyMode(LAUNCH_MODE())) {
     console.warn("[privacy] Production deploys should set VITE_WEBAGENT_LAUNCH_MODE=transit_only_proxy.");
   }
@@ -490,7 +496,7 @@ export default defineConfig(({ mode }) => {
       crossOriginIsolationHeaders(),
       edgeTtsGate(),
       llmProxyGate(),
-      corsProxyGate(),
+      corsProxyGate(proxyEnv),
       react(),
       tailwindcss(),
     ],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes blank SPA load, Nodebox agent bootstrap failures, curator ENOENT on skills, and localhost proxy blocks in development.

## Root causes

1. **`server-task.ts`** — `process.env` at module load in the Vite client bundle.
2. **`constants.ts`** — `node:path` in code imported by the browser shell.
3. **`mcp-config.ts`** — `../../core` imports not copied into Nodebox `.webagent/`.
4. **Workspace roots** — `WS` captured from relative `process.cwd()` before `WEBAGENT_WORKSPACE_ROOT` was applied; `SKILLS_DIR` used stale `WS` → `workspace/<id>/...` ENOENT.
5. **Dev proxy** — SSRF guard blocked `localhost` targets needed for same-origin fetches during `npm run dev`.

## Fixes

- Guard browser-incompatible `process.env` / `node:path` usage.
- Self-contained embed `mcp-config.ts` (no `../../core` imports).
- Prefer `WEBAGENT_WORKSPACE_ROOT` at init; `getSkillsDir()` / `getCapabilitiesDir()` for runtime paths.
- Create `.webagent/skills` when seeding a profile workspace in Nodebox.
- Pass `WEBAGENT_PROXY_ALLOW_PRIVATE=1` to the Vite CORS proxy in development.

## Verification

- [x] `npm test` (925 tests)
- [x] `npx tsc -b --noEmit`
- [x] `npm run build`
- [x] Manual: UI loads; agent boots without proxy/curator errors
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-89c2ac32-e7e6-4de5-97b3-72201ee31270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-89c2ac32-e7e6-4de5-97b3-72201ee31270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

