### PR TITLE
fix: strengthen .webagent workspace orientation every turn

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,9 @@ VITE_WEBAGENT_DEBUG_LOG=0
 VITE_WEBAGENT_DEBUG_LOG_DIR=debug-logs
 WEBAGENT_DEBUG_PROXY=0
 
+# Max UTF-8 bytes per write_file call (default 16 MiB, cap 32 MiB).
+# WEBAGENT_WRITE_FILE_MAX_BYTES=16777216
+
 # Tool loop guardrails — deterministic per-turn loop detection (Hermes-style, warn-first).
 # Warnings append guidance to tool results; hard stops are opt-in.
 VITE_WEBAGENT_TOOL_LOOP_GUARDRAILS_WARNINGS=1

--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -63,7 +63,7 @@ Create `src/capabilities/channels/<channel_id>/`:
 
 Create `src/capabilities/skills/<skill_id>/SKILL.md`.
 
-Bundled skills use the same `SKILL.md` validation as user-created skills. User-created skills in `.webagent/skills/` take precedence over bundled skills with the same slug.
+Bundled skills use the same `SKILL.md` validation as user-created skills. In the **sandbox**, user skills live in `.webagent/skills/<category>/<slug>/` and take precedence over bundled copies under `.webagent/capabilities/skills/`. Install imports with `skill` action=manage `import_dir` — do not copy into `capabilities/skills/`. Host contributors edit `src/capabilities/skills/<skill_id>/SKILL.md`.
 
 **Discovery surface:** Each turn injects a compact index built from frontmatter only (`name`, `description`, optional `triggers`, `tags`) — not the full `SKILL.md` body. Write `description` and `triggers` so they match how users phrase requests; load procedures with `skill_view`.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -89,8 +89,10 @@ The same framing is used for streaming LLM responses (`ipcProxyStreamRequest` in
 
 ## Skills
 
-- Bundled procedures live under `src/capabilities/skills/<id>/SKILL.md` (compact index injected each turn; full body via `skill` action=view).
-- User/imported skills live under `.webagent/skills/`. Remote imports auto-append a **Web Agent execution** compatibility section via `memory/skill-compat.ts` so skills.sh hosts map to built-in tools (`web_fetch`, `web_post`, file tools, etc.).
+- **In the sandbox:** user/imported skills live under `.webagent/skills/<category>/<slug>/SKILL.md` (install via `skill` action=manage `import_dir` after `extract_archive`). Bundled procedures are seeded each launch under `.webagent/capabilities/skills/<id>/` (read-only; included in `skill` action=list — do not copy user skills there).
+- **In the host repo:** contributors edit `src/capabilities/skills/<id>/SKILL.md`; the adapter copies them into `.webagent/capabilities/skills/` on profile boot.
+- Remote imports auto-append a **Web Agent execution** compatibility section via `memory/skill-compat.ts` so skills.sh hosts map to built-in tools (`web_fetch`, `web_post`, file tools, etc.).
+- Every turn injects a **Workspace & filesystem** directory map (`workspace-map.ts` → system prompt + `.webagent/workspace-map.md`).
 
 ## Build pipeline
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-agent",
-  "version": "0.0.68",
+  "version": "0.0.74",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-agent",
-      "version": "0.0.68",
+      "version": "0.0.74",
       "dependencies": {
         "@codesandbox/nodebox": "^0.1.9",
         "@huggingface/transformers": "^3.8.1",

--- a/src/agent/adapter.ts
+++ b/src/agent/adapter.ts
@@ -385,7 +385,10 @@ async function ensureOnboardingFiles(profileId: string): Promise<void> {
     await emulator.fs.writeFile(cronjobsPath, JSON.stringify({ jobs: [] }, null, 2));
   }
 
-  await emulator.fs.mkdir(`${workspaceDir}/.webagent/skills`, { recursive: true });
+  const { workspaceBootstrapDirRels } = await import("@/core/workspace-layout");
+  for (const rel of workspaceBootstrapDirRels()) {
+    await emulator.fs.mkdir(`${workspaceDir}/${rel}`, { recursive: true });
+  }
 
   const toolPolicyPath = `${workspaceDir}/.webagent/tool-policy.json`;
   try {

--- a/src/agent/runtime/memory-guidance.ts
+++ b/src/agent/runtime/memory-guidance.ts
@@ -24,21 +24,27 @@ export const SESSION_SEARCH_GUIDANCE =
   "or `last session` for recency-only browse. Prior-session transcript may already appear in the " +
   "prompt — search when you need older or keyword-specific detail.";
 
+export const WORKSPACE_LAYOUT_GUIDANCE =
+  "Full directory map is in the **Workspace & filesystem** block above (also `.webagent/workspace-map.md`). " +
+  "Deliverables → `projects/<slug>/` or `work/<slug>/` (make_dir first). User/imported skills → `.webagent/skills/<category>/<slug>/` " +
+  "via `skill` import_dir — never `.webagent/capabilities/skills/` (bundled seed only). Telegram/archives → `.webagent/telegram-inbox/` then extract_archive. " +
+  "Host repo paths like `src/capabilities/skills/` are outside the sandbox.";
+
 export const WORKSPACE_BROWSE_GUIDANCE =
-  "Workspace paths in `browse_workspace`, `read_file`, and `grep` are **relative to " +
+  "Workspace paths in `browse_workspace`, `read_file`, `write_file`, and `grep` are **relative to " +
   "the workspace root** (`.` = top level). Never use `/` or host paths like `/home/...`. " +
-  "**First browse step:** run `browse_workspace({\"action\":\"list\",\"path\":\".\"})` or " +
-  "`browse_workspace({\"action\":\"tree\",\"path\":\".\"})` before assuming files exist. " +
+  "**First browse step:** run `browse_workspace({\"action\":\"tree\",\"path\":\".\"})` before assuming paths exist. " +
   "`browse_workspace` **`action`**: `list` (one directory), `tree` (layout), `find` (cross-tree by name). " +
   "`grep` **`root`** is a directory to recurse (default `.`) or a single file path to search. " +
-  "`grep` / browse `find` use **`pattern`**; **`query`** is only for `session_search`.";
+  "`grep` / browse `find` use **`pattern`**; **`query`** is only for `session_search`. " +
+  WORKSPACE_LAYOUT_GUIDANCE;
 
 export const TOOL_JSON_ARGS_GUIDANCE =
   "Tool arguments must be plain JSON with the schema keys each tool declares — do not swap names " +
-  "(grep/browse find: `pattern`; session_search: `query`; read_file/browse_workspace: `path` or `root`; " +
-  "skill (action=view/manage): `name` — not `slug`). " +
-  "Examples: {\"pattern\":\"TODO\"}, {\"query\":\"last outreach\"}, {\"path\":\".\"}. " +
-  "Do not escape property names and do not wrap values in extra quote layers.";
+  "(grep/browse find: `pattern`; session_search: `query`; read_file/write_file: `path` + `content`; " +
+  "browse_workspace: `action` + `path`; skill view/manage: `name` — not `slug`; skill manage: `action` required). " +
+  "Examples: {\"path\":\"projects/demo/out.txt\",\"content\":\"hello\"}, {\"pattern\":\"TODO\"}, " +
+  "{\"action\":\"view\",\"name\":\"http-api\"}. Do not escape property names or wrap values in extra quote layers.";
 
 export const SESSION_MEMORY_GUIDANCE =
   "Use `session_memory_append` for rolling investigation notes, temporary decisions, and artifact " +

--- a/src/agent/runtime/memory-guidance.ts
+++ b/src/agent/runtime/memory-guidance.ts
@@ -39,12 +39,14 @@ export const WORKSPACE_BROWSE_GUIDANCE =
   "`grep` / browse `find` use **`pattern`**; **`query`** is only for `session_search`. " +
   WORKSPACE_LAYOUT_GUIDANCE;
 
+export const WRITE_FILE_GUIDANCE =
+  "write_file: one JSON object `{\"path\":\"projects/<slug>/file.md\",\"content\":\"...\"}` — not markdown-wrapped, not split across pseudo-fields. " +
+  "Full article body goes in `content` as one escaped string (\\n for newlines). Up to 16 MiB per call; split by section if larger.";
+
 export const TOOL_JSON_ARGS_GUIDANCE =
-  "Tool arguments must be plain JSON with the schema keys each tool declares — do not swap names " +
-  "(grep/browse find: `pattern`; session_search: `query`; read_file/write_file: `path` + `content`; " +
-  "browse_workspace: `action` + `path`; skill view/manage: `name` — not `slug`; skill manage: `action` required). " +
-  "Examples: {\"path\":\"projects/demo/out.txt\",\"content\":\"hello\"}, {\"pattern\":\"TODO\"}, " +
-  "{\"action\":\"view\",\"name\":\"http-api\"}. Do not escape property names or wrap values in extra quote layers.";
+  "Tool arguments must be plain JSON with schema keys — grep/browse: `pattern`; session_search: `query`; " +
+  "browse_workspace: `action` + `path`; skill: `name` not `slug`, manage needs `action`. " +
+  WRITE_FILE_GUIDANCE;
 
 export const SESSION_MEMORY_GUIDANCE =
   "Use `session_memory_append` for rolling investigation notes, temporary decisions, and artifact " +
@@ -101,6 +103,9 @@ export function buildMemoryLayerGuidanceBlock(toolNames: string[] = []): string 
     tools.has("session_memory_list")
   ) {
     parts.push(TOOL_JSON_ARGS_GUIDANCE);
+  }
+  if (tools.has("write_file")) {
+    parts.push(WRITE_FILE_GUIDANCE);
   }
   if (
     tools.has("browse_workspace") ||

--- a/src/agent/runtime/tools/argument-normalization.ts
+++ b/src/agent/runtime/tools/argument-normalization.ts
@@ -517,6 +517,17 @@ export function validateRequiredArguments(
   ) {
     hint = ' Use JSON key `name` (not `slug`), e.g. {"name":"http-api"}.';
   }
+  if (toolName === "write_file" && missing.includes("path") && missing.includes("content")) {
+    hint =
+      ' Example: {"path":"projects/my-slug/file.txt","content":"line1\\nline2"}. Both must be top-level JSON strings.';
+  } else if (toolName === "write_file" && missing.includes("content")) {
+    hint = ' Add string field `content` (file body). Example: {"path":"work/notes.md","content":"# Notes"}';
+  } else if (toolName === "write_file" && missing.includes("path")) {
+    hint =
+      ' Add string field `path` (workspace-relative). Example: {"path":"projects/my-slug/out.txt","content":"..."}';
+  } else if (toolName === "skill" && missing.includes("action")) {
+    hint = ' Example: {"action":"list"} or {"action":"manage","manage_action":"import_dir","path":".webagent/telegram-inbox/foo-extracted/my-skill"}';
+  }
   const ex = schema?.examples;
   if (Array.isArray(ex) && ex.length && ex[0] && typeof ex[0] === "object") {
     try {

--- a/src/agent/runtime/tools/argument-normalization.ts
+++ b/src/agent/runtime/tools/argument-normalization.ts
@@ -3,6 +3,13 @@
  */
 
 import { WORKSPACE_LABEL } from "../constants.js";
+import {
+  formatWriteFileMissingFieldsHint,
+  normalizeWriteFileArgs,
+  parseWriteFileToolArguments,
+  salvageWriteFileArgumentsFromRawJson,
+  writeFileArgsMissing,
+} from "./write-file-args.js";
 
 interface JSONSchema {
   type?: string | string[];
@@ -258,17 +265,34 @@ export function repairLooseToolCallObject(raw: unknown): { name: string; argumen
 export function parseToolArguments(raw: unknown, toolName?: string): Record<string, unknown> {
   if (raw == null) return {};
   if (typeof raw === "object" && !Array.isArray(raw)) {
-    return repairMalformedToolArguments(raw as Record<string, unknown>);
+    const repaired = repairMalformedToolArguments(raw as Record<string, unknown>);
+    return toolName === "write_file" ? parseWriteFileToolArguments(raw, repaired) : repaired;
   }
   if (typeof raw === "string") {
     const wire = repairToolCallArgumentsJson(raw, toolName);
     try {
       const parsed = JSON.parse(wire);
       if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-        return repairMalformedToolArguments(parsed as Record<string, unknown>);
+        const repaired = repairMalformedToolArguments(parsed as Record<string, unknown>);
+        if (toolName === "write_file") {
+          return parseWriteFileToolArguments(raw, repaired);
+        }
+        return repaired;
       }
     } catch {
+      if (toolName === "write_file") {
+        const salvaged = salvageWriteFileArgumentsFromRawJson(raw);
+        if (salvaged) {
+          return repairMalformedToolArguments(normalizeWriteFileArgs(salvaged));
+        }
+      }
       return {};
+    }
+    if (toolName === "write_file") {
+      const salvaged = salvageWriteFileArgumentsFromRawJson(raw);
+      if (salvaged) {
+        return repairMalformedToolArguments(normalizeWriteFileArgs(salvaged));
+      }
     }
     return {};
   }
@@ -501,7 +525,16 @@ export function validateRequiredArguments(
   const required = Array.isArray(schema?.required) ? schema.required : [];
   if (!required.length) return null;
 
-  const argsObj = args && typeof args === "object" ? (args as Record<string, unknown>) : {};
+  let argsObj = args && typeof args === "object" ? (args as Record<string, unknown>) : {};
+  if (toolName === "write_file") {
+    argsObj = normalizeWriteFileArgs(argsObj);
+    const writeMissing = writeFileArgsMissing(argsObj);
+    if (!writeMissing.length) return null;
+    let hint = ` ${formatWriteFileMissingFieldsHint(writeMissing)}`;
+    return `invalid arguments: missing required field(s) [${writeMissing.join(
+      ", "
+    )}] for ${toolName}. Provide all required fields from the tool schema.${hint}`;
+  }
   const missing = required.filter((key) => {
     if (!(key in argsObj)) return true;
     return argsObj[key] === undefined;
@@ -517,14 +550,8 @@ export function validateRequiredArguments(
   ) {
     hint = ' Use JSON key `name` (not `slug`), e.g. {"name":"http-api"}.';
   }
-  if (toolName === "write_file" && missing.includes("path") && missing.includes("content")) {
-    hint =
-      ' Example: {"path":"projects/my-slug/file.txt","content":"line1\\nline2"}. Both must be top-level JSON strings.';
-  } else if (toolName === "write_file" && missing.includes("content")) {
-    hint = ' Add string field `content` (file body). Example: {"path":"work/notes.md","content":"# Notes"}';
-  } else if (toolName === "write_file" && missing.includes("path")) {
-    hint =
-      ' Add string field `path` (workspace-relative). Example: {"path":"projects/my-slug/out.txt","content":"..."}';
+  if (toolName === "write_file") {
+    hint = ` ${formatWriteFileMissingFieldsHint(missing)}`;
   } else if (toolName === "skill" && missing.includes("action")) {
     hint = ' Example: {"action":"list"} or {"action":"manage","manage_action":"import_dir","path":".webagent/telegram-inbox/foo-extracted/my-skill"}';
   }

--- a/src/agent/runtime/tools/builtins/write_file.ts
+++ b/src/agent/runtime/tools/builtins/write_file.ts
@@ -1,10 +1,38 @@
 import { defineTool } from "../definition.js";
 import { writeFileTool } from "../filesystem-tools.js";
+import { WRITE_FILE_MAX_BYTES } from "../write-file-args.js";
+
+const maxMiB = (WRITE_FILE_MAX_BYTES / (1024 * 1024)).toFixed(0);
 
 export default defineTool({
   name: "write_file",
   run: writeFileTool,
   emoji: "✍️",
-  description: "Write text to a file, creating parents as needed. Required: `path` (workspace-relative; use a subfolder such as `work/<slug>/` or `projects/<slug>/` for deliverables—bare root names are restricted) and `content` (string). `filename` / `file` are accepted as aliases for `path` when models use artifact-style arguments. For JSON files, pre-serialize with JSON.stringify. Returns { ok, path, bytes }.",
-  inputSchema: { type: "object", properties: { path: { type: "string", description: "Workspace-relative file path (e.g. work/run/file.md)." }, content: { type: "string", description: "Exact file contents as a string." } }, required: ["path", "content"], additionalProperties: true },
+  description:
+    `Write a text file (up to ${maxMiB} MiB). Pass exactly one JSON object with string fields ` +
+    "`path` (workspace-relative, e.g. projects/<slug>/post.md) and `content` (full file body). " +
+    "Do not wrap the tool call in markdown fences. Aliases: contents/text/markdown/body→content; file/filename→path. " +
+    "Returns { ok, path, bytes }.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      path: {
+        type: "string",
+        description: "Workspace-relative file path (e.g. projects/blog/article.md).",
+      },
+      content: {
+        type: "string",
+        maxLength: WRITE_FILE_MAX_BYTES,
+        description: "Full file contents as a single JSON string (escape newlines as \\n).",
+      },
+    },
+    required: ["path", "content"],
+    additionalProperties: true,
+    examples: [
+      {
+        path: "projects/flex-on-the-block/bitnet-1bit-llm.md",
+        content: "# BitNet and 1-bit LLMs\\n\\nOpening paragraph...",
+      },
+    ],
+  },
 });

--- a/src/agent/runtime/tools/error-classifier.ts
+++ b/src/agent/runtime/tools/error-classifier.ts
@@ -424,10 +424,17 @@ function classifyFromMessage(message: string, statusHint: number | null): Omit<C
     retryable = false;
     error_code = message.includes("unknown tool") ? "unknown_tool" : "invalid_arguments";
     shouldFallback = true;
-    const hintBase =
-      /create_archive/i.test(message)
-        ? "There is no create_archive tool. Use run_python with stdlib zipfile to write work/<slug>/bundle.zip, then archive_list and artifact_present."
-        : "Fix tool name and arguments per schema.";
+    let hintBase = "Fix tool name and arguments per schema.";
+    if (/create_archive/i.test(message)) {
+      hintBase =
+        "There is no create_archive tool. Use run_python with stdlib zipfile to write work/<slug>/bundle.zip, then archive_list and artifact_present.";
+    } else if (/write_file/i.test(message) && /missing required.*path|content/i.test(message)) {
+      hintBase =
+        'write_file needs JSON keys `path` and `content` (both strings), e.g. {"path":"projects/my-slug/file.txt","content":"..."}. See Workspace & filesystem map for layout.';
+    } else if (/^skill:/i.test(message) && /missing required.*action/i.test(message)) {
+      hintBase =
+        'skill needs `action` (list|view|manage|bulk), e.g. {"action":"list"} or {"action":"manage","manage_action":"import_dir","path":"<dir-with-SKILL.md>"}.';
+    }
     return { reason, retryable, shouldCompress, shouldFallback, error_code, hintBase };
   }
 

--- a/src/agent/runtime/tools/error-classifier.ts
+++ b/src/agent/runtime/tools/error-classifier.ts
@@ -428,9 +428,9 @@ function classifyFromMessage(message: string, statusHint: number | null): Omit<C
     if (/create_archive/i.test(message)) {
       hintBase =
         "There is no create_archive tool. Use run_python with stdlib zipfile to write work/<slug>/bundle.zip, then archive_list and artifact_present.";
-    } else if (/write_file/i.test(message) && /missing required.*path|content/i.test(message)) {
+    } else if (/write_file/i.test(message) && /missing required|invalid arguments/i.test(message)) {
       hintBase =
-        'write_file needs JSON keys `path` and `content` (both strings), e.g. {"path":"projects/my-slug/file.txt","content":"..."}. See Workspace & filesystem map for layout.';
+        'write_file: one JSON object with string "path" and "content" — not markdown-fenced; see Memory layers → write_file guidance.';
     } else if (/^skill:/i.test(message) && /missing required.*action/i.test(message)) {
       hintBase =
         'skill needs `action` (list|view|manage|bulk), e.g. {"action":"list"} or {"action":"manage","manage_action":"import_dir","path":"<dir-with-SKILL.md>"}.';

--- a/src/agent/runtime/tools/filesystem/path-hints.ts
+++ b/src/agent/runtime/tools/filesystem/path-hints.ts
@@ -70,9 +70,11 @@ function workspaceLayoutHint(input) {
   const base = nodePath.posix.basename(normalizeRelPath(input));
   const findHint = base && base !== input ? ` Or find_files({"pattern":"${base}"}).` : "";
   return (
-    "Paths are relative to workspace root (`.` = top level), not the host repo — " +
-    "run list_dir({\"path\":\".\"}) or tree({\"path\":\".\"}) before assuming package.json, " +
-    `src/, or .webagent/... paths exist.${findHint}`
+    "Paths are workspace-relative (`.` = sandbox root), not the host repo. " +
+    "See the Workspace & filesystem map in the system prompt (or read `.webagent/workspace-map.md`). " +
+    "User skills: `.webagent/skills/<category>/<slug>/` — not `.webagent/capabilities/skills/`. " +
+    "Deliverables: `projects/<slug>/` or `work/<slug>/`. Uploads: `.webagent/telegram-inbox/`. " +
+    `Run browse_workspace({"action":"tree","path":"."}) before assuming paths exist.${findHint}`
   );
 }
 

--- a/src/agent/runtime/tools/filesystem/write.ts
+++ b/src/agent/runtime/tools/filesystem/write.ts
@@ -9,6 +9,11 @@ import {
   ensureParentDir,
 } from "../../workspace-paths.js";
 import { toolPathStringFromArgs, withPathHints } from "./path-hints.js";
+import {
+  WRITE_FILE_MAX_BYTES,
+  formatWriteFileMaxBytesHint,
+  normalizeWriteFileArgs,
+} from "../write-file-args.js";
 
 function coerceWriteContent(raw) {
   if (typeof raw === "string") return raw;
@@ -24,24 +29,25 @@ function coerceWriteContent(raw) {
 }
 
 export async function writeFileTool(args = {}, ctx) {
+  const normalized = normalizeWriteFileArgs(args as Record<string, unknown>);
   const rel =
-    typeof args.path === "string" && args.path.trim()
-      ? args.path.trim()
-      : toolPathStringFromArgs(args);
+    typeof normalized.path === "string" && normalized.path.trim()
+      ? normalized.path.trim()
+      : toolPathStringFromArgs(normalized);
   if (!rel) {
     throw new Error(
       "write_file requires `path` (string), or an alias: `filename`, `file`, `file_path`, `target`"
     );
   }
-  const raw =
-    args.contents !== undefined
-      ? args.contents
-      : args.content !== undefined
-      ? args.content
-      : args.text !== undefined
-      ? args.text
-      : args.data;
+  const raw = normalized.content;
   const contents = coerceWriteContent(raw);
+  const byteLen = Buffer.byteLength(contents, "utf8");
+  if (byteLen > WRITE_FILE_MAX_BYTES) {
+    throw new Error(
+      `write_file: content is ${byteLen} bytes (max ${WRITE_FILE_MAX_BYTES}). ` +
+        `Split into smaller write_file calls (by section) or use run_python to write the file. ${formatWriteFileMaxBytesHint()}`
+    );
+  }
   const abs = resolveWorkspacePath(ctx, rel);
   assertAllowedWorkspaceWritePath(abs);
   await ensureParentDir(abs);
@@ -52,7 +58,7 @@ export async function writeFileTool(args = {}, ctx) {
   return {
     ok: true,
     path: rel,
-    bytes: Buffer.byteLength(contents, "utf8"),
+    bytes: byteLen,
     ...(mcpReload ? { mcp_reload: mcpReload } : {}),
   };
 }

--- a/src/agent/runtime/tools/tool-prep.ts
+++ b/src/agent/runtime/tools/tool-prep.ts
@@ -11,6 +11,7 @@ import { toolPathStringFromArgs } from "./filesystem/path-hints.js";
 import { inferEmailActionArgument } from "./email-tools.js";
 import { hoistNestedToolArguments } from "./llm-arg-shape.js";
 import { normalizeSkillToolCall } from "./skill-tool-normalize.js";
+import { normalizeWriteFileArgs, parseWriteFileToolArguments } from "./write-file-args.js";
 
 export type ToolExecutionContext = ReturnType<typeof createToolContext>;
 
@@ -54,16 +55,7 @@ function applyPathArgAliases(toolName, argsObj) {
 }
 
 function applyWriteFileBodyAliases(argsObj) {
-  if (!argsObj || typeof argsObj !== "object") return argsObj;
-  if (
-    argsObj.content !== undefined ||
-    argsObj.contents !== undefined
-  ) {
-    return argsObj;
-  }
-  if (typeof argsObj.text === "string") return { ...argsObj, content: argsObj.text };
-  if (typeof argsObj.data === "string") return { ...argsObj, content: argsObj.data };
-  return argsObj;
+  return normalizeWriteFileArgs(argsObj as Record<string, unknown>);
 }
 
 function applyWebPostArgAliases(argsObj) {
@@ -134,6 +126,9 @@ export function prepareIncomingToolArguments(
 ): { schema: ReturnType<typeof resolveInputSchema>; args: Record<string, unknown>; name: string } {
   let name = String(toolName || "").trim();
   let parsed = parseToolArguments(rawArgs, name);
+  if (name === "write_file") {
+    parsed = parseWriteFileToolArguments(rawArgs, parsed);
+  }
   parsed = hoistNestedToolArguments(name, parsed) as Record<string, unknown>;
 
   if (name === "email") {
@@ -152,7 +147,7 @@ export function prepareIncomingToolArguments(
     argsForNormalize = applyWorkspaceBrowsePathArgs(name, argsForNormalize);
     argsForNormalize = applyWikiPathArgs(name, argsForNormalize);
     if (name === "write_file") {
-      argsForNormalize = applyWriteFileBodyAliases(argsForNormalize);
+      argsForNormalize = parseWriteFileToolArguments(rawArgs, applyWriteFileBodyAliases(argsForNormalize));
     }
     if (name === "web_post") {
       argsForNormalize = applyWebPostArgAliases(argsForNormalize);

--- a/src/agent/runtime/tools/write-file-args.ts
+++ b/src/agent/runtime/tools/write-file-args.ts
@@ -1,0 +1,146 @@
+/**
+ * write_file argument recovery and size limits.
+ * Large markdown bodies often break strict JSON.parse; salvage path/content from the raw wire string.
+ */
+
+export const WRITE_FILE_MAX_BYTES = Math.max(
+  65_536,
+  Math.min(
+    32 * 1024 * 1024,
+    Number(process.env.WEBAGENT_WRITE_FILE_MAX_BYTES) || 16 * 1024 * 1024
+  )
+);
+
+const PATH_KEY_RE = /"(?:path|file|filename|file_path|filepath|target)"\s*:\s*"/;
+const CONTENT_KEY_RE = /"(?:content|contents|text|data|markdown|body)"\s*:\s*"/;
+
+export function normalizeWriteFileArgs(args: Record<string, unknown>): Record<string, unknown> {
+  if (!args || typeof args !== "object") return {};
+  const out = { ...args };
+  if (out.content === undefined && out.contents !== undefined) out.content = out.contents;
+  if (out.content === undefined && typeof out.text === "string") out.content = out.text;
+  if (out.content === undefined && typeof out.data === "string") out.content = out.data;
+  if (out.content === undefined && typeof out.markdown === "string") out.content = out.markdown;
+  if (out.content === undefined && typeof out.body === "string") out.content = out.body;
+  return out;
+}
+
+function unescapeJsonStringFragment(raw: string): string {
+  let out = "";
+  for (let i = 0; i < raw.length; i += 1) {
+    const ch = raw[i];
+    if (ch !== "\\") {
+      out += ch;
+      continue;
+    }
+    const next = raw[i + 1];
+    if (next === undefined) {
+      out += ch;
+      continue;
+    }
+    if (next === "n") out += "\n";
+    else if (next === "r") out += "\r";
+    else if (next === "t") out += "\t";
+    else     if (next === "u" && /^u[0-9a-fA-F]{4}/.test(raw.slice(i + 1, i + 6))) {
+      out += String.fromCharCode(parseInt(raw.slice(i + 2, i + 6), 16));
+      i += 5;
+    } else out += next;
+    i += 1;
+  }
+  return out;
+}
+
+function readJsonStringValue(text: string, startIdx: number): { value: string; end: number } | null {
+  if (text[startIdx] !== '"') return null;
+  let i = startIdx + 1;
+  let raw = "";
+  while (i < text.length) {
+    const ch = text[i];
+    if (ch === "\\") {
+      raw += ch;
+      if (i + 1 < text.length) {
+        raw += text[i + 1];
+        i += 2;
+        continue;
+      }
+      break;
+    }
+    if (ch === '"') {
+      return { value: unescapeJsonStringFragment(raw), end: i + 1 };
+    }
+    raw += ch;
+    i += 1;
+  }
+  return { value: unescapeJsonStringFragment(raw), end: i };
+}
+
+function readJsonStringField(text: string, keyRe: RegExp): string | null {
+  const m = keyRe.exec(text);
+  if (!m) return null;
+  const parsed = readJsonStringValue(text, m.index + m[0].length - 1);
+  return parsed?.value ?? null;
+}
+
+/** Best-effort extraction when JSON.parse fails or returns an empty object on large writes. */
+export function salvageWriteFileArgumentsFromRawJson(raw: unknown): Record<string, unknown> | null {
+  const text = String(raw ?? "").trim();
+  if (!text || text === "{}") return null;
+  const path = readJsonStringField(text, PATH_KEY_RE);
+  if (!path) return null;
+  const contentMatch = CONTENT_KEY_RE.exec(text);
+  if (!contentMatch) return null;
+  const contentStart = contentMatch.index + contentMatch[0].length - 1;
+  const contentParsed = readJsonStringValue(text, contentStart);
+  if (!contentParsed) return null;
+  return { path, content: contentParsed.value };
+}
+
+export function writeFileArgsMissing(args: Record<string, unknown>): string[] {
+  const normalized = normalizeWriteFileArgs(args);
+  const missing: string[] = [];
+  const path =
+    typeof normalized.path === "string"
+      ? normalized.path.trim()
+      : typeof normalized.file === "string"
+        ? normalized.file.trim()
+        : "";
+  if (!path) missing.push("path");
+  if (normalized.content === undefined) missing.push("content");
+  return missing;
+}
+
+export function parseWriteFileToolArguments(
+  raw: unknown,
+  parsed: Record<string, unknown>
+): Record<string, unknown> {
+  let args = normalizeWriteFileArgs(parsed);
+  if (!writeFileArgsMissing(args).length) return args;
+  if (typeof raw === "string") {
+    const salvaged = salvageWriteFileArgumentsFromRawJson(raw);
+    if (salvaged) args = normalizeWriteFileArgs({ ...args, ...salvaged });
+  }
+  return args;
+}
+
+export function formatWriteFileMaxBytesHint(): string {
+  const mib = (WRITE_FILE_MAX_BYTES / (1024 * 1024)).toFixed(WRITE_FILE_MAX_BYTES % (1024 * 1024) === 0 ? 0 : 1);
+  return `Max ${mib} MiB per write_file (WEBAGENT_WRITE_FILE_MAX_BYTES).`;
+}
+
+export function formatWriteFileMissingFieldsHint(missing: string[]): string {
+  const max = formatWriteFileMaxBytesHint();
+  if (missing.includes("path") && missing.includes("content")) {
+    return (
+      `Emit one JSON object (no markdown code fence around the tool call): ` +
+      `{"path":"projects/<slug>/article.md","content":"# Title\\n\\n..."}. ` +
+      `Aliases map to content/path automatically. ${max}`
+    );
+  }
+  if (missing.includes("content")) {
+    return `Add string field "content" with the full file body in the same JSON object as "path". ${max}`;
+  }
+  if (missing.includes("path")) {
+    return `Add string field "path" (workspace-relative), e.g. "projects/blog/bitnet.md". ${max}`;
+  }
+  return max;
+}

--- a/src/agent/runtime/turn-sequencing.ts
+++ b/src/agent/runtime/turn-sequencing.ts
@@ -192,7 +192,7 @@ export function buildSkillInstallContextPrefix(input) {
   if (!isSkillInstallIntent(input)) return null;
   let prefix =
     "[Skill install] Some GitHub repos are curated indexes (README + outbound links), not skill hosts. " +
-    "For uploaded/extracted skill archives: after `extract_archive`, locate the directory containing `SKILL.md`, then call `skill` with `action: \"manage\"`, `manage_action: \"import_dir\"`, and that directory path. " +
+    "For uploaded/extracted skill archives: after `extract_archive` (from `.webagent/telegram-inbox/` when needed), locate the directory containing `SKILL.md`, then `skill` action=manage manage_action=import_dir path=<that-folder> — installs under `.webagent/skills/<category>/<slug>/`, NOT `.webagent/capabilities/skills/`. " +
     "Read the README, follow registry links (officialskills.sh / skills.sh / skillsmp) or source-repo URLs — " +
     "do not guess raw paths from list labels. On 404: web_fetch registry pages, resolve GitHub links, " +
     "try alternate repo layouts, web_search — pivot before declaring a blocker. " +

--- a/src/agent/runtime/workspace-layout.ts
+++ b/src/agent/runtime/workspace-layout.ts
@@ -1,9 +1,6 @@
 /**
- * Canonical workspace-relative paths for the Nodebox profile cwd
- * (`/workspace/{profileId}` in-browser). Kept in one place so OPFS sync,
- * live listing, and the Files explorer stay aligned with agent runtime tools.
- *
- * Runtime mirror: `src/agent/runtime/workspace-layout.ts` (embed bundle).
+ * Canonical workspace-relative paths for the Nodebox profile cwd.
+ * Mirror of `src/core/workspace-layout.ts` — keep in sync (see tests/workspace-layout-parity.test.ts).
  */
 
 export const WORKSPACE_PROJECTS_DIR_REL = "projects";
@@ -61,7 +58,7 @@ export const WORKSPACE_WEBAGENT_USER_FILES = [
   WORKSPACE_TOOL_POLICY_REL,
 ] as const;
 
-/** Default dirs to show in the Files tree even when empty (matches primary user-facing vaults). */
+/** Default dirs to show in the Files tree even when empty. */
 export const WORKSPACE_EMPTY_DIR_INJECTION: readonly string[] = [
   WORKSPACE_PLANS_DIR_REL,
   WORKSPACE_KNOWLEDGE_VAULT_DIR_REL,

--- a/src/agent/runtime/workspace-map.ts
+++ b/src/agent/runtime/workspace-map.ts
@@ -1,70 +1,116 @@
 /**
  * Runtime filesystem orientation for the agent.
  *
- * The agent runs inside an in-browser Nodebox sandbox rooted at the workspace
- * directory. The host application source (MCP client/host, the IPC adapter, and
- * the host-side tool implementations) lives OUTSIDE this sandbox and is not
- * reachable by any file tool. Without an explicit map the agent wastes turns
- * grepping the workspace for host code that physically isn't there, and
- * second-guesses where its own state files live.
- *
- * `buildWorkspaceMapBlock()` is appended to the system prompt; the same content
- * is written to `.webagent/workspace-map.md` so it is also discoverable via
- * `read_file` and the Files explorer.
+ * `buildWorkspaceMapBlock()` is appended to the system prompt every turn; the same
+ * content is written to `.webagent/workspace-map.md` for read_file / Files explorer.
  */
 
 import fs from "node:fs/promises";
 import {
   WORKSPACE_MAP_REL,
+  WS,
   getMemoryRoot,
   getWorkspaceRoot,
   workspaceStatePath,
 } from "./constants.js";
-import { ensureParentDir } from "./workspace-paths.js";
+import {
+  WORKSPACE_BUNDLED_SKILLS_REL,
+  WORKSPACE_KNOWLEDGE_VAULT_DIR_REL,
+  WORKSPACE_PLANS_DIR_REL,
+  WORKSPACE_PROJECTS_DIR_REL,
+  WORKSPACE_TELEGRAM_INBOX_REL,
+  WORKSPACE_WORK_DIR_REL,
+  workspaceBootstrapDirRels,
+} from "./workspace-layout.js";
+import { ensureParentDir, resolveWorkspacePath } from "./workspace-paths.js";
+import { createToolContext } from "./tools/context.js";
 
-/** Single source of truth for the orientation text. Derived from runtime path constants so it can't drift. */
 export function buildWorkspaceMapBlock(): string {
   const root = getWorkspaceRoot();
   const memory = getMemoryRoot();
   return [
-    "# Workspace & filesystem",
+    "# Workspace & filesystem (injected every turn)",
     "",
-    `You run inside an in-browser Nodebox sandbox. Your workspace root is \`${root}\`.`,
-    "Every file tool (read_file, write_file, grep, find_files, list_dir, tree, browse_workspace)",
-    "resolves paths under this root — relative paths anchor here and the root is the boundary",
-    "(paths that escape it are rejected). The workspace root itself is reserved: put deliverables",
-    "under `projects/<slug>/` or `work/<slug>/` (make_dir first), not at the root.",
+    `Sandbox root: \`${root}\` (display label \`/workspace\`). All file tools resolve paths here.`,
+    "Use workspace-relative paths only — never `/home/...`, never host repo paths like `src/agent/...`.",
     "",
-    "## What lives here, and what persists",
-    "Persisted across sessions (your durable state — safe to read and edit):",
-    "- `.webagent/skills/`, `.webagent/capabilities/`, `.webagent/knowledge-vault/`, `.webagent/checkpoints/`",
-    "- `.webagent/mcp-servers.json`, `.webagent/mcp-secrets.json`, `.webagent/tool-policy.json`",
-    "- `.webagent/history.json`, `.webagent/todos.json`, `.webagent/cronjobs.json`, `.webagent/session-memory.jsonl`,",
-    "  `.webagent/channel-state.json`, `.webagent/heartbeat-state.json`, `.webagent/composio-actions.jsonl`",
-    "- `plans/` (saved `/plan` markdown)",
-    `- \`${memory}/\` (long-term memory: conversations, runs, reflections, snapshots, memory.sqlite)`,
+    "## Directory map (where things belong)",
+    "```",
+    ".                          # workspace root — identity files only; NOT deliverables",
+    "├── AGENT.md USER.md SOUL.md HEARTBEAT.md",
+    `├── ${WORKSPACE_PLANS_DIR_REL}/                 # saved /plan markdown`,
+    `├── ${WORKSPACE_PROJECTS_DIR_REL}/<slug>/        # durable user deliverables (apps, demos, client work)`,
+    `├── ${WORKSPACE_WORK_DIR_REL}/<slug>/            # scratch / spikes / one-off exports`,
+    "├── memory/                  # agent persistence (sql.js + JSON artifacts)",
+    "│   ├── conversations/       # archived chats (session_search)",
+    "│   ├── runs/                # turn logs — tool names/errors ONLY; never grep for API bodies",
+    "│   ├── reflections/ learnings (via sqlite)",
+    "│   ├── snapshots/           # oversized tool-result spill — use list_digest, not scavenger reads",
+    "│   ├── jobs/ channels/",
+    "│   └── memory.sqlite",
+    "└── .webagent/",
+    `    ├── skills/<category>/<slug>/SKILL.md   # USER + imported skills (skill list/manage/import_dir)`,
+    `    ├── ${WORKSPACE_BUNDLED_SKILLS_REL}/<slug>/   # BUNDLED seed — read-only; re-copied each launch`,
+    "    │   └── (do NOT install or copy user skills here)",
+    `    ├── ${WORKSPACE_TELEGRAM_INBOX_REL}/   # Telegram/channel uploads; archives land here`,
+    "    │   └── extract with extract_archive / archive_list (no path = newest inbox zip)",
+    `    ├── ${WORKSPACE_KNOWLEDGE_VAULT_DIR_REL}/  # wiki / knowledge base files`,
+    "    ├── checkpoints/         # /checkpoint rollback snapshots",
+    "    ├── capabilities/      # capability tool handlers (system-seeded)",
+    "    ├── session-memory.jsonl history.json todos.json cronjobs.json …",
+    "    ├── mcp-servers.json mcp-secrets.json tool-policy.json",
+    "    └── workspace-map.md     # this map (also in system prompt)",
+    "```",
     "",
-    "System-seeded and EPHEMERAL — regenerated on every launch, do not hand-edit (changes are lost):",
-    "- `.webagent/tools.json`, `.webagent/providers.json`, `.webagent/browseragent.json`, `.webagent/channels.json`",
-    "- `.webagent/tools-capability-index.md`, `.webagent/workspace-map.md` (this map), `agent.js`",
+    "## Skills (common confusion)",
+    `- **Install / import / edit procedures:** \`.webagent/skills/<category>/<slug>/\` (e.g. \`.webagent/skills/local/my-skill/SKILL.md\`).`,
+    `- **After \`extract_archive\`:** find the folder that contains \`SKILL.md\`, then \`skill\` action=manage manage_action=import_dir path=<that-folder> — do not hand-copy to capabilities.`,
+    `- **Bundled built-ins:** \`${WORKSPACE_BUNDLED_SKILLS_REL}/\` is seeded from the app each launch — \`skill\` action=list already includes them; never move user skills here.`,
+    "- Repo contributor path `src/capabilities/skills/` is **outside** this sandbox (host source only).",
     "",
-    "## The sandbox boundary (read this before debugging the runtime)",
-    "The host application's OWN source code is NOT in this workspace and cannot be found with",
-    "grep / find_files / read_file. That includes the MCP client and host, the IPC adapter that",
-    "bridges your tool calls to the browser, and the host-side implementations of your tools.",
-    "Searching the workspace for symbols like `McpHost`, the IPC adapter, or `mcp_reload` will",
-    "always come up empty — that code runs in the host process, outside the sandbox.",
+    "## Tool path & argument contract",
+    "| Tool | Required path keys | Notes |",
+    "|------|-------------------|-------|",
+    "| read_file, write_file, edit_file, list_dir, tree | `path` | Aliases: `file`, `filename`, `file_path` |",
+    "| write_file | `path` + `content` (both strings) | Large JSON/text: pass full `content`; if encoding fails use `skill` manage or `run_python` copy |",
+    "| grep | `pattern`; optional `root` (dir or file) | Not `query` |",
+    "| browse_workspace | `action` + `path` | `list` \\| `tree` \\| `find` |",
+    "| session_search | `query` | Not `pattern` |",
+    "| skill view/manage | `name` (slug) | Not `slug` key alone |",
+    "| extract_archive | `archive_path` (or omit for newest inbox zip) | Then import_dir on extracted SKILL.md folder |",
+    "| make_dir | `path` | Prefer `projects/<slug>/` or `work/<slug>/` before writes |",
     "",
-    "To debug MCP: inspect/edit `.webagent/mcp-servers.json` and `.webagent/mcp-secrets.json`,",
-    "use the MCP tools, and probe servers directly with `web_post`. Writing either MCP config file",
-    "triggers a host-side reload and the write result reports the new connection status — rely on",
-    "that signal rather than hunting for host source.",
+    "First orientation step when unsure: `browse_workspace({\"action\":\"tree\",\"path\":\".\"})` or `list_dir({\"path\":\".webagent\"})`.",
+    "",
+    "## Persisted vs ephemeral",
+    "Persisted (safe to read/edit): `.webagent/skills/`, `.webagent/knowledge-vault/`, `.webagent/checkpoints/`,",
+    "`.webagent/mcp-*.json`, `.webagent/tool-policy.json`, `.webagent/history.json`, `.webagent/session-memory.jsonl`,",
+    "`plans/`, `projects/`, `work/`,",
+    `\`${memory}/\` (except treat \`memory/runs/\` and \`memory/snapshots/\` as internal — see memory-layers skill).`,
+    "",
+    "Ephemeral (re-seeded each launch — do not hand-edit): `.webagent/tools.json`, `.webagent/providers.json`,",
+    "`.webagent/browseragent.json`, `.webagent/channels.json`, `.webagent/tools-capability-index.md`,",
+    "`.webagent/workspace-map.md`, `.webagent/capabilities/` tree, `agent.js`.",
+    "",
+    "## Sandbox boundary",
+    "Host app source (adapter, MCP host, UI) is NOT in this workspace — grep for `McpHost` or IPC symbols returns nothing.",
+    "Debug MCP via `.webagent/mcp-servers.json` + MCP tools + `web_post`, not by searching for host code.",
     "",
   ].join("\n");
 }
 
-/** Write the same orientation content to `.webagent/workspace-map.md` for on-demand reads and the Files explorer. */
+/** Create standard workspace folders on boot (idempotent). */
+export async function ensureWorkspaceLayoutDirs(cwd = WS): Promise<void> {
+  const ctx = createToolContext({ cwd, runId: "bootstrap" });
+  for (const rel of workspaceBootstrapDirRels()) {
+    const abs = resolveWorkspacePath(ctx, rel);
+    await fs.mkdir(abs, { recursive: true });
+  }
+}
+
+/** Write orientation map to `.webagent/workspace-map.md`. */
 export async function writeWorkspaceMapFile(): Promise<void> {
+  await ensureWorkspaceLayoutDirs().catch(() => {});
   const abs = workspaceStatePath(WORKSPACE_MAP_REL);
   await ensureParentDir(abs);
   await fs.writeFile(abs, buildWorkspaceMapBlock(), "utf8");

--- a/src/agent/runtime/workspace-map.ts
+++ b/src/agent/runtime/workspace-map.ts
@@ -72,7 +72,7 @@ export function buildWorkspaceMapBlock(): string {
     "| Tool | Required path keys | Notes |",
     "|------|-------------------|-------|",
     "| read_file, write_file, edit_file, list_dir, tree | `path` | Aliases: `file`, `filename`, `file_path` |",
-    "| write_file | `path` + `content` (both strings) | Large JSON/text: pass full `content`; if encoding fails use `skill` manage or `run_python` copy |",
+    "| write_file | `path` + `content` (both strings, one JSON object) | Up to 16 MiB; full article in `content`; split sections if larger |",
     "| grep | `pattern`; optional `root` (dir or file) | Not `query` |",
     "| browse_workspace | `action` + `path` | `list` \\| `tree` \\| `find` |",
     "| session_search | `query` | Not `pattern` |",

--- a/src/capabilities/skills/imported-skill-compat/SKILL.md
+++ b/src/capabilities/skills/imported-skill-compat/SKILL.md
@@ -51,7 +51,7 @@ triggers: [imported skill, skills.sh install, skill compat, WebFetch, agent-brow
 | **limited** | Needs Pyodide compatibility checks or host-only shell | pdf (Python), mcp-builder, tdd (shell), **skill-creator** (Python scripts + skip `claude -p`) |
 | **unsupported** | No browser automation in Nodebox | agent-browser, webapp-testing (Playwright) |
 
-Remote imports auto-append a **Web Agent execution (auto-appended)** section to saved `SKILL.md` files under `.webagent/skills/`. Bundled skills under `src/capabilities/skills/` are not patched.
+Remote imports auto-append a **Web Agent execution (auto-appended)** section to saved `SKILL.md` files under `.webagent/skills/<category>/<slug>/`. Bundled skills under `.webagent/capabilities/skills/` (sandbox seed from host `src/capabilities/skills/`) are not patched — never install user skills there; use `skill` action=manage `import_dir` instead.
 
 ## Relation to other skills
 

--- a/src/core/workspace.ts
+++ b/src/core/workspace.ts
@@ -22,6 +22,7 @@ import {
   WORKSPACE_PLANS_DIR_REL,
   WORKSPACE_WEBAGENT_USER_FILES,
   WORKSPACE_WEBAGENT_USER_SUBDIRS,
+  workspaceBootstrapDirRels,
 } from "./workspace-layout";
 
 export * from "./workspace-layout";
@@ -433,10 +434,9 @@ async function listLiveWorkspaceFiles(profileId: string): Promise<WorkspaceFileE
   const results: WorkspaceFileEntry[] = [];
 
   try {
-    for (const sub of WORKSPACE_WEBAGENT_USER_SUBDIRS) {
-      await emulator.fs.mkdir(`${workspaceDir}/.webagent/${sub}`, { recursive: true });
+    for (const rel of workspaceBootstrapDirRels()) {
+      await emulator.fs.mkdir(`${workspaceDir}/${rel}`, { recursive: true });
     }
-    await emulator.fs.mkdir(`${workspaceDir}/${WORKSPACE_PLANS_DIR_REL}`, { recursive: true });
   } catch {
     /* best effort */
   }

--- a/tests/memory-guidance.test.ts
+++ b/tests/memory-guidance.test.ts
@@ -20,8 +20,8 @@ test("buildMemoryLayerGuidanceBlock includes session guidance when session tools
   ]);
   assert.match(block, /session_memory_append/);
   assert.match(block, /past conversation/);
-  assert.match(block, /plain JSON with the schema keys/);
-  assert.match(block, /grep\/browse find: `pattern`/);
+  assert.match(block, /plain JSON with schema keys/);
+  assert.match(block, /session_search: `query`/);
 });
 
 test("buildMemoryLayerGuidanceBlock includes workspace browse guidance for browse_workspace", () => {

--- a/tests/path-hints.test.ts
+++ b/tests/path-hints.test.ts
@@ -23,8 +23,8 @@ test("buildMissingPathHint explains missing parent and workspace layout", async 
     `tmp/_missing_path_hint_${Date.now()}/src/agent/runtime/background-review.ts`
   );
   assert.match(hint, /Path not found:/);
-  assert.match(hint, /workspace root/);
-  assert.match(hint, /list_dir/);
+  assert.match(hint, /workspace-relative|workspace root/i);
+  assert.match(hint, /browse_workspace|workspace-map/);
 });
 
 test("resolveGrepSearchTarget accepts existing file paths", async () => {

--- a/tests/workspace-layout-parity.test.ts
+++ b/tests/workspace-layout-parity.test.ts
@@ -4,20 +4,28 @@
  */
 import assert from "node:assert/strict";
 import test from "node:test";
-import {
-  WORKSPACE_KNOWLEDGE_VAULT_DIR_REL,
-  WORKSPACE_PLANS_DIR_REL,
-  WORKSPACE_SESSION_MEMORY_REL,
-  WORKSPACE_TELEGRAM_AUTH_REL,
-} from "../src/core/workspace-layout";
+import * as coreLayout from "../src/core/workspace-layout";
 
 test("embed runtime path constants match workspace-layout", async () => {
   const { PLANS_DIR_REL, SESSION_MEMORY_PATH, TELEGRAM_AUTH_REL, WS } =
     await import("../dist/agent-runtime/constants.js");
   const { WIKI_DEFAULT_ROOT } = await import("../dist/agent-runtime/tools/wiki-tools.js");
+  const runtimeLayout = await import("../dist/agent-runtime/workspace-layout.js");
 
-  assert.equal(PLANS_DIR_REL, WORKSPACE_PLANS_DIR_REL);
-  assert.equal(TELEGRAM_AUTH_REL, WORKSPACE_TELEGRAM_AUTH_REL);
-  assert.equal(SESSION_MEMORY_PATH, `${WS}/${WORKSPACE_SESSION_MEMORY_REL}`);
-  assert.equal(WIKI_DEFAULT_ROOT, WORKSPACE_KNOWLEDGE_VAULT_DIR_REL);
+  assert.equal(PLANS_DIR_REL, coreLayout.WORKSPACE_PLANS_DIR_REL);
+  assert.equal(TELEGRAM_AUTH_REL, coreLayout.WORKSPACE_TELEGRAM_AUTH_REL);
+  assert.equal(SESSION_MEMORY_PATH, `${WS}/${coreLayout.WORKSPACE_SESSION_MEMORY_REL}`);
+  assert.equal(WIKI_DEFAULT_ROOT, coreLayout.WORKSPACE_KNOWLEDGE_VAULT_DIR_REL);
+
+  assert.deepEqual(
+    [...runtimeLayout.WORKSPACE_WEBAGENT_USER_SUBDIRS],
+    [...coreLayout.WORKSPACE_WEBAGENT_USER_SUBDIRS]
+  );
+  assert.deepEqual(
+    [...runtimeLayout.WORKSPACE_MEMORY_SUBDIRS],
+    [...coreLayout.WORKSPACE_MEMORY_SUBDIRS]
+  );
+  assert.deepEqual(runtimeLayout.workspaceBootstrapDirRels(), coreLayout.workspaceBootstrapDirRels());
+  assert.equal(runtimeLayout.WORKSPACE_TELEGRAM_INBOX_REL, coreLayout.WORKSPACE_TELEGRAM_INBOX_REL);
+  assert.equal(runtimeLayout.WORKSPACE_BUNDLED_SKILLS_REL, coreLayout.WORKSPACE_BUNDLED_SKILLS_REL);
 });

--- a/tests/workspace-map.test.ts
+++ b/tests/workspace-map.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { workspaceBootstrapDirRels, WORKSPACE_TELEGRAM_INBOX_REL } from "../src/core/workspace-layout";
+
+test("workspaceBootstrapDirRels includes standard vaults", () => {
+  const dirs = workspaceBootstrapDirRels();
+  assert.ok(dirs.includes("projects"));
+  assert.ok(dirs.includes("work"));
+  assert.ok(dirs.includes(WORKSPACE_TELEGRAM_INBOX_REL));
+  assert.ok(dirs.includes(".webagent/skills"));
+  assert.ok(dirs.includes("memory/runs"));
+  assert.equal(new Set(dirs).size, dirs.length);
+});
+
+test("embed buildWorkspaceMapBlock documents skills vs capabilities", async () => {
+  const { buildWorkspaceMapBlock } = await import("../dist/agent-runtime/workspace-map.js");
+  const block = buildWorkspaceMapBlock();
+  assert.match(block, /\.webagent\/skills\/<category>/);
+  assert.match(block, /\.webagent\/capabilities\/skills/);
+  assert.match(block, /do NOT install/i);
+  assert.match(block, /write_file.*`path`.*`content`/i);
+});

--- a/tests/write-file-args.test.ts
+++ b/tests/write-file-args.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  WRITE_FILE_MAX_BYTES,
+  normalizeWriteFileArgs,
+  parseWriteFileToolArguments,
+  salvageWriteFileArgumentsFromRawJson,
+} from "../dist/agent-runtime/tools/write-file-args.js";
+import { validateRequiredArguments } from "../dist/agent-runtime/tools/argument-normalization.js";
+import { prepareIncomingToolArguments } from "../dist/agent-runtime/tools/tool-prep.js";
+
+test("normalizeWriteFileArgs maps body aliases to content", () => {
+  assert.equal(
+    normalizeWriteFileArgs({ path: "work/a.md", markdown: "# Hi" }).content,
+    "# Hi"
+  );
+  assert.equal(
+    normalizeWriteFileArgs({ path: "work/a.md", contents: "x" }).content,
+    "x"
+  );
+});
+
+test("salvageWriteFileArgumentsFromRawJson recovers path and large content", () => {
+  const body = "# Title\n\n".repeat(200);
+  const raw = `{"path":"projects/blog/post.md","content":${JSON.stringify(body)}}`;
+  const broken = raw.slice(0, -3);
+  const salvaged = salvageWriteFileArgumentsFromRawJson(broken);
+  assert.ok(salvaged);
+  assert.equal(salvaged?.path, "projects/blog/post.md");
+  assert.ok(String(salvaged?.content).startsWith("# Title"));
+});
+
+test("parseWriteFileToolArguments salvages when JSON.parse yields empty object", () => {
+  const raw = `{"path":"work/x.txt","content":"line1\\nline2"}`;
+  const args = parseWriteFileToolArguments(raw, {});
+  assert.equal(args.path, "work/x.txt");
+  assert.equal(args.content, "line1\nline2");
+});
+
+test("validateRequiredArguments accepts contents alias for write_file", () => {
+  const err = validateRequiredArguments(
+    "write_file",
+    { path: "work/a.md", contents: "ok" },
+    { type: "object", required: ["path", "content"], properties: {} }
+  );
+  assert.equal(err, null);
+});
+
+test("prepareIncomingToolArguments salvages broken write_file wire", () => {
+  const article = "## Section\n\n".repeat(50);
+  const raw = `{"path":"projects/demo/article.md","content":${JSON.stringify(article)}}`;
+  const broken = raw.replace(/"}$/, "");
+  const { args, name } = prepareIncomingToolArguments("write_file", broken, {
+    inputSchema: {
+      type: "object",
+      required: ["path", "content"],
+      properties: { path: { type: "string" }, content: { type: "string" } },
+    },
+  });
+  assert.equal(name, "write_file");
+  assert.equal(args.path, "projects/demo/article.md");
+  assert.ok(String(args.content).includes("## Section"));
+});
+
+test("WRITE_FILE_MAX_BYTES defaults to 16 MiB", () => {
+  assert.equal(WRITE_FILE_MAX_BYTES, 16 * 1024 * 1024);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Agents were burning turns on wrong paths (e.g. installing skills under `.webagent/capabilities/skills/` instead of `.webagent/skills/`, misusing `write_file` args, and grepping host repo paths). This adds a **full directory map on every turn**, pre-creates standard folders on first boot, and tightens tool/path error hints.

Also fixes **write_file** failures on large articles where JSON parsing collapses to `{}` and reports missing `path`/`content` even when the model intended to send them.

## What changed

### Workspace orientation
- **Per-turn map** (`buildWorkspaceMapBlock`): ASCII tree, skills vs capabilities, telegram inbox flow, tool argument table
- **Canonical layout** in `workspace-layout.ts` (core + runtime mirror); `workspaceBootstrapDirRels()` on boot
- Sharper path hints, skill-install prefix, docs updates

### write_file (16 MiB default)
- **`WEBAGENT_WRITE_FILE_MAX_BYTES`** — default **16 MiB** (cap 32 MiB)
- **Salvage** path/content from broken/truncated JSON wire strings when `JSON.parse` fails
- **Aliases**: `contents`, `markdown`, `body` → `content`
- **Single guidance** in memory layers (`WRITE_FILE_GUIDANCE`) — no repeated syntax blocks in errors/map

## Verification

- [x] `npm test` (946 pass)
- [x] `npm run build:embed-runtime`
- [x] `npx tsc -b --noEmit`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6fd82496-f2e2-4771-88d8-0eaa65831df5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6fd82496-f2e2-4771-88d8-0eaa65831df5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

